### PR TITLE
Release v0.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body_path: docs/release-notes/v${{ steps.version.outputs.version }}.md
+          fail_on_unmatched_files: true
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
           files: |
             artifacts/AgentDock-${{ steps.version.outputs.version }}-setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Strip any prerelease suffix (e.g. -beta.1, -rc.2) so all prereleases
+          # of a target version share one release-notes file
+          # (v0.10.0-beta.1 → docs/release-notes/v0.10.0.md).
+          BASE_VERSION="${VERSION%%-*}"
+          echo "base_version=$BASE_VERSION" >> "$GITHUB_OUTPUT"
           if [[ "$VERSION" == *-* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -70,7 +75,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          body_path: docs/release-notes/v${{ steps.version.outputs.version }}.md
+          body_path: docs/release-notes/v${{ steps.version.outputs.base_version }}.md
           fail_on_unmatched_files: true
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
           files: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,6 +8,8 @@ Before installing Agent Dock, make sure you have the following:
 
 Agent Dock is a Windows desktop application. macOS and Linux are not supported at this time.
 
+> **Voice dictation** (the microphone button in the AI Chat) requires Windows 10 version 2004 (build 19041, May 2020) or later. On older Win10 builds the rest of the app works fine; the mic button is just hidden.
+
 ### 2. .NET 10 Runtime
 
 Agent Dock is built on .NET 10. Download and install the **desktop runtime** from Microsoft:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -239,6 +239,53 @@ Fetch and integrate Develorem logo. App icon for taskbar/title bar. Consistent s
 
 ---
 
+## Task 15: Tab Restyle + Tab Groups
+**Status:** `[ ]`
+
+Two related changes to the project tab strip:
+
+**A. Restyle project tabs (VS Code-like)**
+Replace the current button-style ControlTemplate in `MainWindow.xaml.cs` (`CreateProjectTabButton`, ~lines 967-978) with flat rectangular tabs:
+- Inactive: transparent background.
+- Active: subtle themed fill + ~2px themed bottom-edge accent.
+- Hover: slight background lift, no border.
+- Tabs sit flush with the content area below (no gap, no rounded button corners).
+
+**B. Tab groups ("meta tabs")**
+A new optional grouping layer above the project tab row, hidden until the user creates a group.
+
+- **Creation:** Right-click a project tab → existing context menu gains "Add to new group". First use creates a group named "Group 1" containing that tab and an implicit "Ungrouped" group holding everything else. Subsequent uses increment: "Group 2", "Group 3", …
+- **Meta bar visibility:** Zero height / no chrome when only one group exists. Appears as a thin horizontal row above `ToolbarPanel` once 2+ groups exist.
+- **Meta tab styling:** Lighter-weight than project tabs (label-only chip), active group shows themed bottom accent.
+- **Click meta tab:** Switches active group; project tab row filters to that group's projects only.
+- **Inline rename:** Click the group's text label → inline TextBox. Commit on focus-loss or Enter; Esc cancels. ("Ungrouped" is renameable like any other group.)
+- **Right-click meta tab:** Context menu with "Delete group" — enabled only when the group has zero projects.
+- **Drag-drop:** A project tab dragged onto a meta tab moves the project to that group. Extends existing `ToolbarPanel_DragOver/Drop` handlers.
+- **Toolbar orientation:** When toolbar is on top, meta bar is a row above project tabs. For left/right/bottom toolbar positions, mirror the layout (meta column adjacent to project column). Parity across all four orientations.
+
+**Persistence (workspace file):**
+- Bump `WorkspaceFile.Version` to `2`.
+- Add `Groups: [{ Id, Name, Order }]` to `WorkspaceFile`.
+- Add nullable `GroupId` to `WorkspaceProject`.
+- Add `ActiveGroupId` so the active group restores on load.
+- Loader: v1 files (no Groups field) load with all projects ungrouped, meta bar hidden.
+
+**Done criteria:**
+- Project tabs render in flat VS Code-like style; active and hover states clearly distinct, themed.
+- No meta bar visible until a group is created.
+- Right-click → "Add to new group" creates "Group 1" and an "Ungrouped" group; meta bar appears.
+- Subsequent "Add to new group" produces "Group 2", "Group 3", …
+- Clicking a meta tab filters the project tab row to that group's projects only.
+- Click on a group's name → inline rename works (Enter commits, Esc cancels, focus-loss commits).
+- Right-click a meta tab shows "Delete group", disabled when group has tabs.
+- Dragging a project tab onto a meta tab reassigns its group.
+- Meta bar layout adapts to all four toolbar positions (top/left/right/bottom).
+- Workspace save/load round-trips groups, group names, group order, and active group.
+- v1 workspace files still load cleanly (treated as all-ungrouped, meta bar hidden).
+- Release notes updated under `docs/release-notes/v{next}.md`.
+
+---
+
 ## Workflow
 
 1. Each task is implemented incrementally

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -1,5 +1,15 @@
 # v0.9.0
 
+## Chat: Voice Dictation
+
+- New microphone button inside the chat input chrome — click once to start dictating, click again to stop. Recognized phrases insert at the current caret position so you can dictate, edit, and dictate again
+- Uses Windows' built-in offline speech recognition (`Windows.Media.SpeechRecognition`); no cloud calls and no API keys required
+- The mic button glows red while listening; tooltips explain the current state
+- First click triggers Windows' microphone permission prompt; if denied or no language pack is installed, the button shows an error tooltip pointing to the relevant Windows settings
+- Auto-stops when the session leaves the Idle state (e.g. while Claude is working) so dictation never runs into a disabled input
+- Requires **Windows 10 version 2004 (build 19041) or later**; on older Win10 builds the mic button is hidden and the rest of the app keeps working
+- The app's target framework was bumped to `net10.0-windows10.0.19041.0` to project the WinRT speech APIs. The installer still installs on any Windows 10 — only the dictation feature is OS-gated, at runtime
+
 ## Chat: Clickable File References
 
 - File paths in Claude's responses (e.g. `src/AgentDock/Services/ClaudeSession.cs` or `./docs/TASKS.md`) are now rendered as clickable links in the rendered-markdown view

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -1,5 +1,12 @@
 # v0.9.0
 
+## Chat: Clickable File References
+
+- File paths in Claude's responses (e.g. `src/AgentDock/Services/ClaudeSession.cs` or `./docs/TASKS.md`) are now rendered as clickable links in the rendered-markdown view
+- Clicking a link reveals the file in the project File Explorer (expanding parent folders) and shows it in the File Preview pane
+- Only paths that actually resolve to a file under the project root are linked; bare filenames without a directory component are left as plain text to avoid wrong matches
+- Paths inside fenced code blocks are intentionally not linkified (they're usually code, not navigation)
+
 ## Chat Input: Integrated Prompt Marker
 
 - The `>` prompt marker now lives **inside** the chat input chrome, so the input feels like one widget (a styled border around `>` + textbox) rather than two adjacent ones

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -103,7 +103,15 @@
   - **Beta**: scans all releases including pre-releases, picks the highest SemVer, and auto-updates between successive betas *and* to the eventual stable release. Intended for machines you've volunteered to test pre-release builds on
 - SemVer ordering is implemented properly: `1.0.0` > `1.0.0-rc.1` > `1.0.0-beta.10` > `1.0.0-beta.2`, so a beta tester moving through `beta.1 → beta.2 → rc.1 → 1.0.0` gets each one in order without ever stepping back
 
-## Build / Internal
+## Tabs: VS Code-style Look + Tab Groups
+
+- Project tabs have been restyled to look like proper tabs rather than buttons. The active tab gets a subtle background fill and a 2px themed accent bar along its bottom edge; inactive tabs are transparent and pick up a faint hover tint. No more corner-rounded buttons floating in the toolbar
+- New **tab groups** (a "meta tab" layer) for large workspaces. The meta strip is invisible until you create your first group, so the default look is unchanged
+- Right-click any project tab → **Add to new group**. The first time you do this, the workspace splits into two groups: a new auto-named *Group 1* containing that tab, and an *Ungrouped* group containing every other tab. Subsequent uses create *Group 2*, *Group 3*, etc.
+- Clicking a meta tab switches the active group; the project-tab row filters down to just that group's tabs. Clicking the *already active* meta tab puts its name into an inline editor — Enter or click-away commits, Esc cancels. (The default *Ungrouped* name is renameable like any other.)
+- Right-click a meta tab to **Delete group** — only enabled when the group has no tabs. Deleting the second-to-last group dissolves the grouping completely, putting the workspace back into its pristine no-meta-bar state
+- Drag a project tab onto a meta tab to move that project into the target group. The drop target highlights while you're hovering it
+- Groups, group names, group order, the active group, and each project's group assignment are saved with the workspace (`.agentdock` file format bumped to v2). Older v1 workspace files still load — they come up with no groups defined, exactly as before
 
 - Release notes markdown for every shipped version is now embedded as a resource in the assembly, so the *What's New* popup works offline
 - `<Version>` in the project file is now kept in sync with the release branch (was stale at 0.3.0)

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -1,11 +1,24 @@
 # v0.9.0
 
+## Chat Input: Integrated Prompt Marker
+
+- The `>` prompt marker now lives **inside** the chat input chrome, so the input feels like one widget (a styled border around `>` + textbox) rather than two adjacent ones
+- The textbox itself has no border — the wrapper border carries the chrome, mimicking a real terminal prompt
+- In multi-line mode the `>` stays anchored at the top while the textbox grows downward
+- Clicking anywhere in the prompt chrome focuses the textbox
+
 ## Markdown: Bold Across Code Spans and Links
 
 - Fixed a long-standing rendering bug where bold did not apply when the bold span contained a code span or partial link
 - Examples that previously rendered with literal asterisks: `` **use `git` here** ``, `**See [foo](url) more**`, and the same patterns inside numbered or bulleted lists
 - Root cause: MdXaml's parser consumes inline atoms (code spans, links) before emphasis, leaving the asterisks orphaned around the atom
 - The fix splits the bold around each atom so each `**...**` pair stays on one side of the atom (e.g. `` **use `git` here** `` → `` **use** `git` **here** ``)
+
+## File Preview: JSON Syntax Highlighting
+
+- JSON files in the file preview pane now render with proper syntax colors instead of flat text
+- Object keys, string values, numbers, booleans, `null`, and punctuation each get their own theme-aware brush, so the colors match whichever theme you're using (light or dark)
+- Implemented as an AvalonEdit `DocumentColorizingTransformer` so it picks up theme changes live without reloading the file
 
 ## App Version in Title Bar
 

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -86,6 +86,15 @@
 - Previously, busy repos (large `node_modules` installs, bulk file generation, build output) overflowed the buffer with `"Too many changes at once"` and the control fell back to 3-second polling for the rest of the session
 - Now the live watcher keeps up in those scenarios, so git status stays real-time
 
+## Chat: Virtualized Message List
+
+- The chat-history rendering has been rebuilt around a virtualizing `ItemsControl`. Previously the chat was a `ScrollViewer` wrapping a `StackPanel` of fully-realized Borders, TextBoxes and `MarkdownScrollViewer`s, so every layout pass (including every tab switch) had to measure and arrange every past message. On long sessions this is what made switching projects feel sticky, and what made even interacting with elements inside one tab slow
+- Each message is now a view-model rendered through a data template; the panel only realizes containers for messages currently visible in the viewport plus a small buffer. Off-screen messages cost effectively nothing in measure/arrange
+- Past messages are modelled as **immutable** classes — no `INotifyPropertyChanged`, no allocation per access, no listener subscriptions. Only the currently-streaming assistant text, the currently-building execution bubble, and the (temporary) inactivity-warning carry INPC. When a message finalizes, its live VM is swapped in the collection for an immutable counterpart, after which it has no event subscribers — nothing left to leak
+- Markdown rendering happens **once**: when an assistant message finalizes, its `FlowDocument` is built and cached on the immutable message. The same document instance is re-attached to whichever recycled `MarkdownScrollViewer` materializes for it later — scrolling past a long code-block message and back doesn't re-parse the markdown
+- Streaming deltas are coalesced through a ~30 fps throttle inside the streaming VM. A model that emits hundreds of token-deltas per second produces one binding update per frame instead of one per delta
+- Sticky-bottom auto-scroll: the chat follows new content when the user is at the bottom, but doesn't yank them back down if they've scrolled up to read history (during streaming or when a new message arrives)
+
 ## Build / Internal
 
 - Release notes markdown for every shipped version is now embedded as a resource in the assembly, so the *What's New* popup works offline

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -1,0 +1,25 @@
+# v0.9.0
+
+## Markdown: Bold Across Code Spans and Links
+
+- Fixed a long-standing rendering bug where bold did not apply when the bold span contained a code span or partial link
+- Examples that previously rendered with literal asterisks: `` **use `git` here** ``, `**See [foo](url) more**`, and the same patterns inside numbered or bulleted lists
+- Root cause: MdXaml's parser consumes inline atoms (code spans, links) before emphasis, leaving the asterisks orphaned around the atom
+- The fix splits the bold around each atom so each `**...**` pair stays on one side of the atom (e.g. `` **use `git` here** `` → `` **use** `git` **here** ``)
+
+## App Version in Title Bar
+
+- The window title bar now shows the running app version next to the product name (e.g. `Agent Dock v0.9.0`)
+- Makes it easy to see at a glance which version is installed without opening the About dialog
+
+## Release Notes Now Visible Throughout
+
+- **GitHub Releases page** — releases now show the curated changelog from `docs/release-notes/v{X.Y.Z}.md` instead of an auto-generated commit list
+- **Update dialog** — when an update is available, the dialog now shows the new version's release notes inline so you can see what's changed before clicking *Update Now*
+- **What's New popup** — after the app updates and restarts, a popup shows the release notes for the new version on first launch. Shown once per version; suppressed on first install
+- **About dialog** — added a *Release Notes* link that opens the GitHub releases page
+
+## Build / Internal
+
+- Release notes markdown for every shipped version is now embedded as a resource in the assembly, so the *What's New* popup works offline
+- `<Version>` in the project file is now kept in sync with the release branch (was stale at 0.3.0)

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -1,5 +1,12 @@
 # v0.9.0
 
+## Settings: Two New Dialogs
+
+- The **Settings** menu now opens dedicated dialogs instead of long submenus: **Workspace Settings…** and **App Settings…**
+- Each dialog has a left-rail section list and an OK / Cancel pattern. Theme, Toolbar Position, Claude Path Override, and Open Logs Folder all live in App Settings now (split across *Appearance*, *Integrations*, and *Diagnostics* sections)
+- Workspace Settings currently exposes Theme and Toolbar Position for the active workspace; the dialog is laid out so future workspace-scoped settings can drop in alongside
+- Replaces the previous Theme submenu, Toolbar Position submenu, Claude Path Override... dialog flow, and Open Logs Folder menu items
+
 ## Chat: Voice Dictation
 
 - New microphone button inside the chat input chrome — click once to start dictating, click again to stop. Recognized phrases insert at the current caret position so you can dictate, edit, and dictate again

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -61,6 +61,31 @@
 - **What's New popup** — after the app updates and restarts, a popup shows the release notes for the new version on first launch. Shown once per version; suppressed on first install
 - **About dialog** — added a *Release Notes* link that opens the GitHub releases page
 
+## Window: Reliable Taskbar Restore
+
+- Fixed a serious bug where a long-running instance could refuse to come back from the taskbar — clicking its taskbar entry played the Windows default-beep "ding" and the window stayed minimized
+- Root cause: Windows' foreground-lock timeout was expiring our process's privilege to be activated by the shell. With `WindowStyle="None"` + a custom WindowChrome the symptom is more visible because there's no system menu fallback
+- Two-part fix: at app startup we disable the per-user foreground-lock timeout (in-memory only, not persisted to the registry), and on every minimize we call `AllowSetForegroundWindow(ASFW_ANY)` so the next external activation request (e.g. an explorer.exe taskbar click) is always granted
+- Both defences work together — the startup fix covers cold-restore from the taskbar; the minimize-time grant survives long idle periods without depending on system-wide state
+
+## Logs: No More Token-Delta Spam
+
+- Streaming-token deltas (`stream_event` lines) are no longer written to the per-session log file. They previously fired dozens of times per second during a long response and could grow one session's log past 100 MB
+- The events are still parsed and dispatched to the chat UI exactly as before — only the disk write is skipped
+- System init, assistant messages, tool results, control requests, and result messages all still log normally, so a session log remains useful for debugging
+
+## Chat: No More Empty Thinking Bubbles
+
+- The empty "Thinking" bubble that appeared on every assistant turn is gone
+- Root cause: `claude-opus-4-7` returns **redacted** thinking blocks — the wire sends `content_block_start` with `type=thinking` (so a bubble was being created) but the thinking text is empty and only a cryptographic `signature_delta` follows. No `thinking_delta` events ever arrive
+- Fix: the thinking bubble is now created lazily on the first real `thinking_delta`. If a model only sends a redacted thinking block, no empty bubble appears. Models that do stream thinking text (e.g. with extended thinking summaries enabled) still get a populated bubble, exactly as before
+
+## Git Status: Survive Busy Repos
+
+- The git-status FileSystemWatcher's internal buffer is bumped from the default 8 KB to 64 KB
+- Previously, busy repos (large `node_modules` installs, bulk file generation, build output) overflowed the buffer with `"Too many changes at once"` and the control fell back to 3-second polling for the rest of the session
+- Now the live watcher keeps up in those scenarios, so git status stays real-time
+
 ## Build / Internal
 
 - Release notes markdown for every shipped version is now embedded as a resource in the assembly, so the *What's New* popup works offline

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -95,6 +95,14 @@
 - Streaming deltas are coalesced through a ~30 fps throttle inside the streaming VM. A model that emits hundreds of token-deltas per second produces one binding update per frame instead of one per delta
 - Sticky-bottom auto-scroll: the chat follows new content when the user is at the bottom, but doesn't yank them back down if they've scrolled up to read history (during streaming or when a new message arrives)
 
+## Pre-release Channel for Test Builds
+
+- The release workflow now recognises SemVer pre-release tags like `v0.10.0-beta.1` or `v0.10.0-rc.2`. Pushing such a tag publishes a GitHub release flagged as a pre-release; all pre-releases for a given target version share the one `docs/release-notes/v{X.Y.Z}.md` file
+- New **App Settings → Updates → Release Channel** picker with two options:
+  - **Stable** (default): only ever auto-updates to official releases. Pre-releases are skipped both server-side (`/releases/latest` excludes them) and client-side
+  - **Beta**: scans all releases including pre-releases, picks the highest SemVer, and auto-updates between successive betas *and* to the eventual stable release. Intended for machines you've volunteered to test pre-release builds on
+- SemVer ordering is implemented properly: `1.0.0` > `1.0.0-rc.1` > `1.0.0-beta.10` > `1.0.0-beta.2`, so a beta tester moving through `beta.1 → beta.2 → rc.1 → 1.0.0` gets each one in order without ever stepping back
+
 ## Build / Internal
 
 - Release notes markdown for every shipped version is now embedded as a resource in the assembly, so the *What's New* popup works offline

--- a/docs/release-notes/v0.9.0.md
+++ b/docs/release-notes/v0.9.0.md
@@ -7,6 +7,11 @@
 - Only paths that actually resolve to a file under the project root are linked; bare filenames without a directory component are left as plain text to avoid wrong matches
 - Paths inside fenced code blocks are intentionally not linkified (they're usually code, not navigation)
 
+## File Preview: Reveal File from Diff
+
+- When previewing a git-status diff, a new toolbar button at the top-right of the preview pane jumps from the diff to the full file: it expands the File Explorer to the file, selects it, and switches the preview from the diff to the full file contents
+- Same plumbing as the chat-link reveal — clicking it raises `FileSelected` so any future trigger that selects a file will also open the preview automatically
+
 ## Chat Input: Integrated Prompt Marker
 
 - The `>` prompt marker now lives **inside** the chat input chrome, so the input feels like one widget (a styled border around `>` + textbox) rather than two adjacent ones

--- a/installer/AgentDock.iss
+++ b/installer/AgentDock.iss
@@ -30,6 +30,10 @@ PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
+; .NET 10 desktop apps require Windows 10 or later. The dictation feature
+; additionally requires Win10 build 19041; that's checked at runtime so older
+; Win10 installs simply hide the mic button.
+MinVersion=10.0
 ChangesAssociations=yes
 ChangesEnvironment=yes
 SetupIconFile=..\assets\agentdock.ico

--- a/src/AgentDock/AgentDock.csproj
+++ b/src/AgentDock/AgentDock.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>

--- a/src/AgentDock/AgentDock.csproj
+++ b/src/AgentDock/AgentDock.csproj
@@ -15,9 +15,9 @@
     <Authors>Develorem</Authors>
     <Description>Manage multiple Claude Code AI sessions across projects from a single window.</Description>
     <Copyright>Copyright (c) 2026 Develorem</Copyright>
-    <Version>0.3.0</Version>
-    <AssemblyVersion>0.3.0.0</AssemblyVersion>
-    <FileVersion>0.3.0.0</FileVersion>
+    <Version>0.9.0</Version>
+    <AssemblyVersion>0.9.0.0</AssemblyVersion>
+    <FileVersion>0.9.0.0</FileVersion>
     <RepositoryUrl>https://github.com/develorem/agent-dock</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <ApplicationIcon>..\..\assets\agentdock.ico</ApplicationIcon>
@@ -39,6 +39,10 @@
 
   <ItemGroup>
     <Resource Include="..\..\assets\agentdock.png" Link="Assets\agentdock.png" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\docs\release-notes\v*.md" LogicalName="ReleaseNotes/%(Filename).md" />
   </ItemGroup>
 
 </Project>

--- a/src/AgentDock/App.xaml.cs
+++ b/src/AgentDock/App.xaml.cs
@@ -16,11 +16,23 @@ public partial class App : Application
     [DllImport("kernel32.dll")]
     private static extern bool AttachConsole(int dwProcessId);
 
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool SystemParametersInfo(uint uiAction, uint uiParam, IntPtr pvParam, uint fWinIni);
+
     private const int AttachParentProcess = -1;
+    private const uint SPI_SETFOREGROUNDLOCKTIMEOUT = 0x2001;
 
     protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
+
+        // Disable the per-user foreground-lock timeout so the shell can always
+        // bring our window to the front (taskbar click on a minimized window).
+        // Without this, a long-running instance whose foreground privilege has
+        // expired plays the default-beep ding and refuses to restore from the
+        // taskbar. SPIF flags = 0 means in-memory only, not persisted to the
+        // registry — the setting resets next reboot.
+        SystemParametersInfo(SPI_SETFOREGROUNDLOCKTIMEOUT, 0, IntPtr.Zero, 0);
 
         // Parse command-line arguments before initializing the logger,
         // so we know the logs folder and session context.

--- a/src/AgentDock/Controls/AiChatControl.xaml
+++ b/src/AgentDock/Controls/AiChatControl.xaml
@@ -310,6 +310,22 @@
                                            FontSize="12" FontWeight="Bold"
                                            Foreground="{DynamicResource ChatInputPromptForeground}" />
                             </Button>
+                            <Button x:Name="MicButton"
+                                    DockPanel.Dock="Right"
+                                    Click="MicButton_Click"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Cursor="Hand"
+                                    Padding="0"
+                                    VerticalAlignment="Bottom"
+                                    Margin="4,0,6,4"
+                                    ToolTip="Start dictation">
+                                <TextBlock x:Name="MicIcon"
+                                           Text="&#xE720;"
+                                           FontFamily="Segoe MDL2 Assets"
+                                           FontSize="14"
+                                           Foreground="{DynamicResource ChatMutedForeground}" />
+                            </Button>
                             <TextBox x:Name="InputBox"
                                      FontFamily="Cascadia Code, Consolas, Courier New"
                                      FontSize="12"

--- a/src/AgentDock/Controls/AiChatControl.xaml
+++ b/src/AgentDock/Controls/AiChatControl.xaml
@@ -239,21 +239,6 @@
                     BorderThickness="0,1,0,0"
                     Padding="8,6">
                 <DockPanel>
-                    <Button x:Name="PromptMenuButton"
-                            DockPanel.Dock="Left"
-                            Click="PromptMenu_Click"
-                            Background="Transparent"
-                            BorderThickness="0"
-                            Cursor="Hand"
-                            Padding="0"
-                            VerticalAlignment="Bottom"
-                            Margin="0,0,6,3"
-                            ToolTip="Commands">
-                        <TextBlock Text=">"
-                                   FontFamily="Cascadia Code, Consolas, Courier New"
-                                   FontSize="14" FontWeight="Bold"
-                                   Foreground="{DynamicResource ChatInputPromptForeground}" />
-                    </Button>
                     <Button x:Name="SendButton"
                             Content="Send"
                             Click="Send_Click"
@@ -303,24 +288,47 @@
                             </ListBox>
                         </Border>
                     </Popup>
-                    <TextBox x:Name="InputBox"
-                             FontFamily="Cascadia Code, Consolas, Courier New"
-                             FontSize="12"
-                             Foreground="{DynamicResource ChatInputForeground}"
-                             Background="{DynamicResource ChatInputBackground}"
-                             CaretBrush="{DynamicResource ChatInputForeground}"
-                             BorderBrush="{DynamicResource ChatInputBorderBrush}"
-                             BorderThickness="1"
-                             Padding="6,4"
-                             AcceptsReturn="True"
-                             TextWrapping="Wrap"
-                             VerticalScrollBarVisibility="Auto"
-                             MaxHeight="76"
-                             MinHeight="28"
-                             KeyDown="InputBox_KeyDown"
-                             PreviewKeyDown="InputBox_PreviewKeyDown"
-                             TextChanged="InputBox_TextChanged"
-                             VerticalContentAlignment="Top" />
+                    <Border x:Name="InputBorder"
+                            Background="{DynamicResource ChatInputBackground}"
+                            BorderBrush="{DynamicResource ChatInputBorderBrush}"
+                            BorderThickness="1"
+                            VerticalAlignment="Bottom"
+                            MouseLeftButtonDown="InputBorder_MouseLeftButtonDown">
+                        <DockPanel LastChildFill="True">
+                            <Button x:Name="PromptMenuButton"
+                                    DockPanel.Dock="Left"
+                                    Click="PromptMenu_Click"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Cursor="Hand"
+                                    Padding="0"
+                                    VerticalAlignment="Top"
+                                    Margin="6,4,4,0"
+                                    ToolTip="Commands">
+                                <TextBlock Text=">"
+                                           FontFamily="Cascadia Code, Consolas, Courier New"
+                                           FontSize="12" FontWeight="Bold"
+                                           Foreground="{DynamicResource ChatInputPromptForeground}" />
+                            </Button>
+                            <TextBox x:Name="InputBox"
+                                     FontFamily="Cascadia Code, Consolas, Courier New"
+                                     FontSize="12"
+                                     Foreground="{DynamicResource ChatInputForeground}"
+                                     Background="Transparent"
+                                     CaretBrush="{DynamicResource ChatInputForeground}"
+                                     BorderThickness="0"
+                                     Padding="0,4,6,4"
+                                     AcceptsReturn="True"
+                                     TextWrapping="Wrap"
+                                     VerticalScrollBarVisibility="Auto"
+                                     MaxHeight="76"
+                                     MinHeight="20"
+                                     KeyDown="InputBox_KeyDown"
+                                     PreviewKeyDown="InputBox_PreviewKeyDown"
+                                     TextChanged="InputBox_TextChanged"
+                                     VerticalContentAlignment="Top" />
+                        </DockPanel>
+                    </Border>
                 </DockPanel>
             </Border>
 

--- a/src/AgentDock/Controls/AiChatControl.xaml
+++ b/src/AgentDock/Controls/AiChatControl.xaml
@@ -3,6 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:models="clr-namespace:AgentDock.Models"
+             xmlns:mdxaml="clr-namespace:MdXaml;assembly=MdXaml"
              mc:Ignorable="d"
              Background="{DynamicResource ChatBackground}">
     <UserControl.Resources>
@@ -21,6 +23,75 @@
             <Setter Property="Foreground" Value="{DynamicResource ChatTextForeground}" />
             <Setter Property="FontSize" Value="13" />
         </Style>
+
+        <!-- Read-only selectable text used inside message bubbles. Borderless,
+             transparent background, no focus chrome — looks like a TextBlock
+             but allows text selection. -->
+        <Style x:Key="ChatSelectableText" TargetType="TextBox">
+            <Setter Property="FontFamily" Value="Cascadia Code, Consolas, Courier New" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="IsReadOnly" Value="True" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="VerticalScrollBarVisibility" Value="Disabled" />
+        </Style>
+
+        <!-- Chevron used to expand/collapse thinking/execution bubbles. -->
+        <Style x:Key="ChatChevron" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="Cascadia Code, Consolas, Courier New" />
+            <Setter Property="FontSize" Value="10" />
+            <Setter Property="Foreground" Value="{DynamicResource ChatMutedForeground}" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Margin" Value="0,0,4,0" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="Text" Value="▶" />
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsExpanded}" Value="True">
+                    <Setter Property="Text" Value="▼" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <!-- Each ToolEntry inside an execution bubble. -->
+        <DataTemplate DataType="{x:Type models:ToolEntry}">
+            <StackPanel Margin="0,0,0,6">
+                <TextBlock Text="{Binding Name, StringFormat='[Tool: {0}]'}"
+                           FontFamily="Cascadia Code, Consolas, Courier New"
+                           FontSize="10"
+                           Foreground="{DynamicResource ChatExecutionForeground}" />
+                <TextBox Text="{Binding FormattedInput, Mode=OneTime}"
+                         Style="{StaticResource ChatSelectableText}"
+                         FontSize="10"
+                         Foreground="{DynamicResource ChatExecutionForeground}"
+                         Margin="0,2,0,0" />
+            </StackPanel>
+        </DataTemplate>
+
+        <!-- AssistantMessage: plain-source view. Used when IsMarkdownView=False
+             or when the message has no markdown to render. -->
+        <DataTemplate x:Key="AssistantTextTemplate">
+            <TextBox Text="{Binding Text, Mode=OneTime}"
+                     Style="{StaticResource ChatSelectableText}"
+                     FontSize="12"
+                     Foreground="{DynamicResource ChatTextForeground}" />
+        </DataTemplate>
+
+        <!-- AssistantMessage: rendered-markdown view. The MarkdownScrollViewer's
+             content is set in code-behind on DataContextChanged so it survives
+             container recycling without leaking handlers. -->
+        <DataTemplate x:Key="AssistantMarkdownTemplate">
+            <mdxaml:MarkdownScrollViewer x:Name="MdViewer"
+                                         Background="Transparent"
+                                         Foreground="{DynamicResource ChatTextForeground}"
+                                         MarkdownStyle="{StaticResource ChatMarkdownStyle}"
+                                         VerticalScrollBarVisibility="Disabled"
+                                         HorizontalScrollBarVisibility="Disabled"
+                                         Padding="0"
+                                         DataContextChanged="AssistantMarkdown_DataContextChanged"
+                                         Loaded="AssistantMarkdown_Loaded" />
+        </DataTemplate>
     </UserControl.Resources>
     <Grid>
         <!-- Start session overlay (shown when no session is active) -->
@@ -348,15 +419,376 @@
                 </DockPanel>
             </Border>
 
-            <!-- Message list -->
-            <ScrollViewer x:Name="MessageScroller"
-                          VerticalScrollBarVisibility="Auto"
-                          HorizontalScrollBarVisibility="Disabled"
+            <!-- Message list — virtualized. Past messages are immutable record-ish
+                 VMs; only the currently-streaming / currently-building entries
+                 carry INPC. The ItemsControl template wraps the items panel in
+                 a ScrollViewer so VirtualizingStackPanel can implement IScrollInfo
+                 and only realize containers for visible items. -->
+            <ItemsControl x:Name="MessageList"
                           Background="{DynamicResource ChatBackground}"
-                          PreviewMouseWheel="MessageScroller_PreviewMouseWheel">
-                <StackPanel x:Name="MessageList"
-                            Margin="8,8,8,8" />
-            </ScrollViewer>
+                          Padding="8"
+                          ScrollViewer.CanContentScroll="True"
+                          VirtualizingPanel.IsVirtualizing="True"
+                          VirtualizingPanel.VirtualizationMode="Recycling"
+                          VirtualizingPanel.ScrollUnit="Pixel"
+                          PreviewMouseWheel="MessageList_PreviewMouseWheel">
+                <ItemsControl.Template>
+                    <ControlTemplate TargetType="ItemsControl">
+                        <ScrollViewer x:Name="MessageScroller"
+                                      Padding="{TemplateBinding Padding}"
+                                      Background="{TemplateBinding Background}"
+                                      VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled"
+                                      CanContentScroll="True">
+                            <ItemsPresenter />
+                        </ScrollViewer>
+                    </ControlTemplate>
+                </ItemsControl.Template>
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.Resources>
+
+                    <!-- UserMessage: right-aligned bubble, "You" label, selectable text. -->
+                    <DataTemplate DataType="{x:Type models:UserMessage}">
+                        <Border Background="{DynamicResource ChatUserBubbleBackground}"
+                                CornerRadius="8,8,2,8"
+                                Padding="10,6"
+                                Margin="40,4,8,4"
+                                HorizontalAlignment="Right">
+                            <StackPanel>
+                                <TextBlock Text="You"
+                                           FontFamily="Cascadia Code, Consolas, Courier New"
+                                           FontSize="10"
+                                           Foreground="{DynamicResource ChatUserLabelForeground}"
+                                           Margin="0,0,0,2" />
+                                <TextBox Text="{Binding Text, Mode=OneTime}"
+                                         Style="{StaticResource ChatSelectableText}"
+                                         FontSize="12"
+                                         Foreground="{DynamicResource ChatTextForeground}" />
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+
+                    <!-- SystemMessage: centered subtle text, danger color when IsWarning. -->
+                    <DataTemplate DataType="{x:Type models:SystemMessage}">
+                        <TextBlock Text="{Binding Text, Mode=OneTime}"
+                                   FontFamily="Cascadia Code, Consolas, Courier New"
+                                   FontSize="10"
+                                   HorizontalAlignment="Center"
+                                   TextWrapping="Wrap"
+                                   Margin="8,6">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Foreground" Value="{DynamicResource ChatSubtleForeground}" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsWarning}" Value="True">
+                                            <Setter Property="Foreground" Value="{DynamicResource ChatDangerForeground}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </DataTemplate>
+
+                    <!-- WaitingMessage: transient "Thinking..." placeholder shown after
+                         the user sends, until the first delta arrives. -->
+                    <DataTemplate DataType="{x:Type models:WaitingMessage}">
+                        <Border Background="{DynamicResource ChatThinkingBackground}"
+                                CornerRadius="6"
+                                Padding="8,4"
+                                Margin="8,2,40,2"
+                                HorizontalAlignment="Left"
+                                BorderBrush="{DynamicResource ChatThinkingBorderBrush}"
+                                BorderThickness="1">
+                            <TextBlock Text="Thinking..."
+                                       FontFamily="Cascadia Code, Consolas, Courier New"
+                                       FontSize="11"
+                                       Foreground="{DynamicResource ChatMutedForeground}"
+                                       FontStyle="Italic" />
+                        </Border>
+                    </DataTemplate>
+
+                    <!-- StreamingThinkingMessage: live thinking text being appended. -->
+                    <DataTemplate DataType="{x:Type models:StreamingThinkingMessage}">
+                        <Border Background="{DynamicResource ChatThinkingBackground}"
+                                CornerRadius="6"
+                                Padding="8,4"
+                                Margin="8,2,40,2"
+                                HorizontalAlignment="Left"
+                                BorderBrush="{DynamicResource ChatThinkingBorderBrush}"
+                                BorderThickness="1">
+                            <StackPanel>
+                                <TextBlock Text="Thinking"
+                                           FontFamily="Cascadia Code, Consolas, Courier New"
+                                           FontSize="10"
+                                           Foreground="{DynamicResource ChatSubtleForeground}"
+                                           FontStyle="Italic"
+                                           Margin="0,0,0,2" />
+                                <TextBox Text="{Binding Text, Mode=OneWay}"
+                                         Style="{StaticResource ChatSelectableText}"
+                                         FontSize="11"
+                                         Foreground="{DynamicResource ChatMutedForeground}"
+                                         FontStyle="Italic" />
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+
+                    <!-- ThinkingMessage (finalized): collapsible, body hidden by default. -->
+                    <DataTemplate DataType="{x:Type models:ThinkingMessage}">
+                        <Border Background="{DynamicResource ChatThinkingBackground}"
+                                CornerRadius="6"
+                                Padding="8,4"
+                                Margin="8,2,40,2"
+                                HorizontalAlignment="Left"
+                                BorderBrush="{DynamicResource ChatThinkingBorderBrush}"
+                                BorderThickness="1">
+                            <StackPanel>
+                                <StackPanel Orientation="Horizontal"
+                                            Background="Transparent"
+                                            Cursor="Hand"
+                                            MouseLeftButtonUp="ThinkingHeader_Click"
+                                            Tag="{Binding}">
+                                    <TextBlock Style="{StaticResource ChatChevron}" />
+                                    <TextBlock Text="Thinking"
+                                               FontFamily="Cascadia Code, Consolas, Courier New"
+                                               FontSize="10"
+                                               Foreground="{DynamicResource ChatSubtleForeground}"
+                                               FontStyle="Italic" />
+                                </StackPanel>
+                                <TextBox Text="{Binding Text, Mode=OneTime}"
+                                         Style="{StaticResource ChatSelectableText}"
+                                         FontSize="11"
+                                         Foreground="{DynamicResource ChatMutedForeground}"
+                                         FontStyle="Italic"
+                                         Margin="0,2,0,0">
+                                    <TextBox.Visibility>
+                                        <Binding Path="IsExpanded">
+                                            <Binding.Converter>
+                                                <BooleanToVisibilityConverter />
+                                            </Binding.Converter>
+                                        </Binding>
+                                    </TextBox.Visibility>
+                                </TextBox>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+
+                    <!-- BuildingExecutionMessage: live tool-call list for the current turn. -->
+                    <DataTemplate DataType="{x:Type models:BuildingExecutionMessage}">
+                        <Border Background="{DynamicResource ChatExecutionBackground}"
+                                CornerRadius="6"
+                                Padding="8,4"
+                                Margin="8,2,40,2"
+                                HorizontalAlignment="Left"
+                                BorderBrush="{DynamicResource ChatExecutionBorderBrush}"
+                                BorderThickness="1">
+                            <StackPanel>
+                                <StackPanel Orientation="Horizontal"
+                                            Background="Transparent"
+                                            Cursor="Hand"
+                                            MouseLeftButtonUp="BuildingExecutionHeader_Click"
+                                            Tag="{Binding}">
+                                    <TextBlock Style="{StaticResource ChatChevron}" />
+                                    <TextBlock Text="Execution"
+                                               FontFamily="Cascadia Code, Consolas, Courier New"
+                                               FontSize="10"
+                                               Foreground="{DynamicResource ChatExecutionForeground}"
+                                               FontStyle="Italic" />
+                                </StackPanel>
+                                <ItemsControl ItemsSource="{Binding Tools}" Margin="0,2,0,0">
+                                    <ItemsControl.Visibility>
+                                        <Binding Path="IsExpanded">
+                                            <Binding.Converter>
+                                                <BooleanToVisibilityConverter />
+                                            </Binding.Converter>
+                                        </Binding>
+                                    </ItemsControl.Visibility>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+
+                    <!-- ExecutionMessage (finalized): same look, immutable Tools list. -->
+                    <DataTemplate DataType="{x:Type models:ExecutionMessage}">
+                        <Border Background="{DynamicResource ChatExecutionBackground}"
+                                CornerRadius="6"
+                                Padding="8,4"
+                                Margin="8,2,40,2"
+                                HorizontalAlignment="Left"
+                                BorderBrush="{DynamicResource ChatExecutionBorderBrush}"
+                                BorderThickness="1">
+                            <StackPanel>
+                                <StackPanel Orientation="Horizontal"
+                                            Background="Transparent"
+                                            Cursor="Hand"
+                                            MouseLeftButtonUp="ExecutionHeader_Click"
+                                            Tag="{Binding}">
+                                    <TextBlock Style="{StaticResource ChatChevron}" />
+                                    <TextBlock Text="Execution"
+                                               FontFamily="Cascadia Code, Consolas, Courier New"
+                                               FontSize="10"
+                                               Foreground="{DynamicResource ChatExecutionForeground}"
+                                               FontStyle="Italic" />
+                                </StackPanel>
+                                <ItemsControl ItemsSource="{Binding Tools}" Margin="0,2,0,0">
+                                    <ItemsControl.Visibility>
+                                        <Binding Path="IsExpanded">
+                                            <Binding.Converter>
+                                                <BooleanToVisibilityConverter />
+                                            </Binding.Converter>
+                                        </Binding>
+                                    </ItemsControl.Visibility>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+
+                    <!-- StreamingAssistantMessage: live text being appended. Plain text only
+                         during streaming — markdown rendering happens on finalize. -->
+                    <DataTemplate DataType="{x:Type models:StreamingAssistantMessage}">
+                        <Border Background="{DynamicResource ChatAssistantBubbleBackground}"
+                                CornerRadius="8,8,8,2"
+                                Padding="10,6"
+                                Margin="8,4,40,4"
+                                HorizontalAlignment="Left">
+                            <StackPanel>
+                                <TextBlock Text="Claude"
+                                           FontFamily="Cascadia Code, Consolas, Courier New"
+                                           FontSize="10"
+                                           Foreground="{DynamicResource ChatAssistantLabelForeground}"
+                                           Margin="0,0,0,2" />
+                                <TextBox Text="{Binding Text, Mode=OneWay}"
+                                         Style="{StaticResource ChatSelectableText}"
+                                         FontSize="12"
+                                         Foreground="{DynamicResource ChatTextForeground}" />
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+
+                    <!-- AssistantMessage (finalized): switches between source and rendered
+                         markdown via a Style/DataTrigger on the ContentControl so only the
+                         active template is realized. -->
+                    <DataTemplate DataType="{x:Type models:AssistantMessage}">
+                        <Border Background="{DynamicResource ChatAssistantBubbleBackground}"
+                                CornerRadius="8,8,8,2"
+                                Padding="10,6"
+                                Margin="8,4,40,4"
+                                HorizontalAlignment="Left">
+                            <StackPanel>
+                                <DockPanel>
+                                    <Button DockPanel.Dock="Right"
+                                            Click="MarkdownToggle_Click"
+                                            Tag="{Binding}"
+                                            Cursor="Hand"
+                                            Background="Transparent"
+                                            BorderBrush="{DynamicResource ChatThinkingBorderBrush}"
+                                            BorderThickness="1"
+                                            Padding="4,2"
+                                            Opacity="0.7">
+                                        <Button.Style>
+                                            <Style TargetType="Button">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                <Setter Property="ToolTip" Value="Switch to source view" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding HasMarkdownToggle}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible" />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding IsMarkdownView}" Value="False">
+                                                        <Setter Property="ToolTip" Value="Switch to rendered view" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Button.Style>
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" FontSize="11"
+                                                   Foreground="{DynamicResource ChatMutedForeground}">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Text" Value="&#xE943;" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsMarkdownView}" Value="False">
+                                                            <Setter Property="Text" Value="&#xE890;" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </Button>
+                                    <TextBlock Text="Claude"
+                                               FontFamily="Cascadia Code, Consolas, Courier New"
+                                               FontSize="10"
+                                               Foreground="{DynamicResource ChatAssistantLabelForeground}"
+                                               Margin="0,0,0,2" />
+                                </DockPanel>
+                                <ContentControl Content="{Binding}">
+                                    <ContentControl.Style>
+                                        <Style TargetType="ContentControl">
+                                            <Setter Property="ContentTemplate" Value="{StaticResource AssistantTextTemplate}" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsMarkdownView}" Value="True">
+                                                    <Setter Property="ContentTemplate" Value="{StaticResource AssistantMarkdownTemplate}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </ContentControl.Style>
+                                </ContentControl>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+
+                    <!-- InactivityWarning: warning bubble with ticking elapsed text and two buttons. -->
+                    <DataTemplate DataType="{x:Type models:InactivityWarning}">
+                        <Border Background="{DynamicResource ChatWarningBackground}"
+                                CornerRadius="6"
+                                Padding="10,8"
+                                Margin="8,4"
+                                BorderBrush="{DynamicResource ChatWarningBorderBrush}"
+                                BorderThickness="1">
+                            <StackPanel>
+                                <TextBlock Text="Claude hasn't responded for a while — it may be stuck."
+                                           FontFamily="Cascadia Code, Consolas, Courier New"
+                                           FontSize="11"
+                                           Foreground="{DynamicResource ChatStatusWarningForeground}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,0,0,4" />
+                                <TextBlock Text="{Binding ElapsedText}"
+                                           FontFamily="Cascadia Code, Consolas, Courier New"
+                                           FontSize="10"
+                                           Foreground="{DynamicResource ChatMutedForeground}"
+                                           Margin="0,0,0,6" />
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Content="Wait longer"
+                                            Click="InactivityWait_Click"
+                                            Tag="{Binding}"
+                                            Cursor="Hand"
+                                            FontFamily="Cascadia Code, Consolas, Courier New"
+                                            FontSize="11"
+                                            Background="{DynamicResource ChatButtonBackground}"
+                                            Foreground="{DynamicResource ChatButtonForeground}"
+                                            BorderBrush="{DynamicResource ChatButtonBorderBrush}"
+                                            BorderThickness="1"
+                                            Padding="10,4"
+                                            Margin="0,0,8,0" />
+                                    <Button Content="Kill process"
+                                            Click="InactivityKill_Click"
+                                            Tag="{Binding}"
+                                            Cursor="Hand"
+                                            FontFamily="Cascadia Code, Consolas, Courier New"
+                                            FontSize="11"
+                                            Background="{DynamicResource ChatKillButtonBackground}"
+                                            Foreground="{DynamicResource ChatDangerForeground}"
+                                            BorderBrush="{DynamicResource ChatKillButtonBorderBrush}"
+                                            BorderThickness="1"
+                                            Padding="10,4" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+
+                </ItemsControl.Resources>
+            </ItemsControl>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/src/AgentDock/Controls/AiChatControl.xaml.cs
+++ b/src/AgentDock/Controls/AiChatControl.xaml.cs
@@ -105,6 +105,18 @@ public partial class AiChatControl : UserControl
             Dispatcher.BeginInvoke(() => InputBox.Focus(), System.Windows.Threading.DispatcherPriority.Input);
     }
 
+    // Clicks on the prompt border (outside the textbox itself, e.g. between the > and
+    // the text) should land focus in the textbox so the chrome behaves like one widget.
+    private void InputBorder_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.OriginalSource == InputBorder && InputBox.IsEnabled)
+        {
+            InputBox.Focus();
+            InputBox.CaretIndex = InputBox.Text.Length;
+            e.Handled = true;
+        }
+    }
+
     public void Shutdown()
     {
         _session?.Dispose();

--- a/src/AgentDock/Controls/AiChatControl.xaml.cs
+++ b/src/AgentDock/Controls/AiChatControl.xaml.cs
@@ -638,17 +638,12 @@ public partial class AiChatControl : UserControl
     {
         RemoveWaitingBubble();
 
-        if (evt.BlockType == "thinking")
-        {
-            // Start a new thinking bubble
-            _thinkingText = "";
-            _thinkingBlock = CreateSelectableText(11,
-                ThemeManager.GetBrush("ChatMutedForeground"),
-                FontStyles.Italic);
-            _thinkingBubble = CreateThinkingBubble(_thinkingBlock);
-            _thinkingExpanded = true;
-            MessageList.Children.Add(_thinkingBubble);
-        }
+        // Don't create the thinking bubble eagerly here. claude-opus-4-7 returns
+        // *redacted* thinking blocks — content_block_start fires with type=thinking
+        // but no thinking_delta events ever arrive (only a signature_delta), so an
+        // eagerly-created bubble would stay empty forever. OnThinkingDelta creates
+        // the bubble lazily on the first real delta, so models that do stream
+        // thinking text still get a populated bubble.
     }
 
     private void OnContentBlockStopped(ClaudeContentBlockEvent evt)

--- a/src/AgentDock/Controls/AiChatControl.xaml.cs
+++ b/src/AgentDock/Controls/AiChatControl.xaml.cs
@@ -97,6 +97,11 @@ public partial class AiChatControl : UserControl
         Log.Info("AiChatControl: constructor");
         InitializeComponent();
         Log.Info("AiChatControl: InitializeComponent complete");
+
+        // Older Win10 builds don't ship the WinRT dictation recognizer — hide the
+        // mic button rather than show one that would always error.
+        if (!DictationService.IsSupportedOnThisOS)
+            MicButton.Visibility = Visibility.Collapsed;
     }
 
     public void Initialize(string projectPath)
@@ -127,6 +132,73 @@ public partial class AiChatControl : UserControl
     {
         _session?.Dispose();
         _session = null;
+        _dictation?.Dispose();
+        _dictation = null;
+    }
+
+    // --- Dictation ---
+
+    private DictationService? _dictation;
+
+    private async void MicButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dictation == null)
+        {
+            _dictation = new DictationService();
+            _dictation.TextRecognized += text => Dispatcher.BeginInvoke(() => InsertDictatedText(text));
+            _dictation.StateChanged += state => Dispatcher.BeginInvoke(() => UpdateMicVisual(state));
+            _dictation.ErrorOccurred += msg => Dispatcher.BeginInvoke(() => SetMicErrorTooltip(msg));
+        }
+        try
+        {
+            await _dictation.ToggleAsync();
+        }
+        catch (Exception ex)
+        {
+            Log.Error("Dictation toggle failed", ex);
+            SetMicErrorTooltip(ex.Message);
+        }
+    }
+
+    private void InsertDictatedText(string text)
+    {
+        var caret = InputBox.CaretIndex;
+        var existing = InputBox.Text;
+        var needsLeadingSpace = caret > 0 && caret <= existing.Length
+            && !char.IsWhiteSpace(existing[caret - 1]);
+        var insert = (needsLeadingSpace ? " " : "") + text;
+        InputBox.Text = existing.Insert(caret, insert);
+        InputBox.CaretIndex = caret + insert.Length;
+    }
+
+    private void UpdateMicVisual(DictationState state)
+    {
+        switch (state)
+        {
+            case DictationState.Idle:
+                MicIcon.Foreground = ThemeManager.GetBrush("ChatMutedForeground");
+                MicButton.ToolTip = "Start dictation";
+                break;
+            case DictationState.Starting:
+                MicIcon.Foreground = ThemeManager.GetBrush("ChatMutedForeground");
+                MicButton.ToolTip = "Starting…";
+                break;
+            case DictationState.Listening:
+                MicIcon.Foreground = ThemeManager.GetBrush("ChatDangerForeground");
+                MicButton.ToolTip = "Listening — click to stop";
+                break;
+            case DictationState.Stopping:
+                MicButton.ToolTip = "Stopping…";
+                break;
+            case DictationState.Error:
+                MicIcon.Foreground = ThemeManager.GetBrush("ChatMutedForeground");
+                break;
+        }
+    }
+
+    private void SetMicErrorTooltip(string message)
+    {
+        MicButton.ToolTip = $"Dictation error: {message}";
     }
 
     // --- Start Session ---
@@ -214,6 +286,9 @@ public partial class AiChatControl : UserControl
         var canSend = state == ClaudeSessionState.Idle;
         InputBox.IsEnabled = canSend;
         SendButton.IsEnabled = canSend;
+        MicButton.IsEnabled = canSend;
+        if (!canSend && _dictation?.IsActive == true)
+            _ = _dictation.StopAsync();
 
         if (canSend)
             FocusInput();

--- a/src/AgentDock/Controls/AiChatControl.xaml.cs
+++ b/src/AgentDock/Controls/AiChatControl.xaml.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
@@ -16,37 +18,34 @@ public partial class AiChatControl : UserControl
     private ClaudeSession? _session;
     private string _projectPath = "";
 
-    // Tracks the currently streaming message block so we can append deltas
-    private TextBox? _streamingBlock;
-    private string _streamingText = "";
+    // The virtualized chat list. Past messages are immutable VM classes;
+    // only the live tail (streaming text, building execution, inactivity
+    // warning) carries INPC. Past-message containers in the
+    // VirtualizingStackPanel are realized only when scrolled into view.
+    public ObservableCollection<ChatMessageVm> Messages { get; } = [];
 
-    // Thinking bubble tracking
-    private TextBox? _thinkingBlock;
-    private string _thinkingText = "";
-    private Border? _thinkingBubble;
-    private bool _thinkingExpanded = true; // expanded while streaming, collapsed when done
+    // Live-tail references — set when the corresponding VM is in the
+    // collection, nulled on finalize / removal.
+    private StreamingAssistantMessage? _streamingVm;
+    private StreamingThinkingMessage? _streamingThinkingVm;
+    private BuildingExecutionMessage? _executionVm;
+    private WaitingMessage? _waitingVm;
+    private InactivityWarning? _inactivityVm;
+    private DispatcherTimer? _inactivityElapsedTimer;
 
-    // Animated working indicator
+    // Animated working indicator in the status bar (not a message).
     private DispatcherTimer? _workingTimer;
     private int _spinnerIndex;
     private static readonly string[] SpinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
-    // In-chat thinking placeholder (shown when Working, no deltas yet)
-    private Border? _waitingBubble;
-
-    // Execution bubble — groups tool-use blocks under a collapsible heading
-    private TextBox? _executionContentBlock;
-    private string _executionFullText = "";
-    private Border? _executionBubble;
-
-    // Pending AskUserQuestion — tracks question text for response
+    // Pending AskUserQuestion — tracks question text for response.
     private string? _pendingQuestionText;
 
-    // Inactivity warning bubble (removable when activity resumes)
-    private Border? _inactivityWarning;
-    private DispatcherTimer? _inactivityElapsedTimer;
-    private TextBlock? _inactivityElapsedText;
+    // Last user message timestamp, for the inactivity warning's elapsed text.
     private DateTime _lastMessageSentTime;
+
+    // Inner ScrollViewer of the ItemsControl, cached after template is applied.
+    private ScrollViewer? _scrollViewer;
 
     /// <summary>
     /// Raised when session state changes (for toolbar icon updates).
@@ -96,6 +95,8 @@ public partial class AiChatControl : UserControl
     {
         Log.Info("AiChatControl: constructor");
         InitializeComponent();
+        MessageList.ItemsSource = Messages;
+        Messages.CollectionChanged += OnMessagesChanged;
         Log.Info("AiChatControl: InitializeComponent complete");
 
         // Older Win10 builds don't ship the WinRT dictation recognizer — hide the
@@ -249,7 +250,6 @@ public partial class AiChatControl : UserControl
 
     private void OnStateChanged(ClaudeSessionState state)
     {
-        // Stop the working animation for any state change
         StopWorkingAnimation();
 
         if (state == ClaudeSessionState.Working)
@@ -277,7 +277,6 @@ public partial class AiChatControl : UserControl
             _ => ThemeManager.GetBrush("ChatMutedForeground")
         };
 
-        // Show danger icon when session is active in dangerous mode
         var showDanger = _session?.IsDangerousMode == true
             && state != ClaudeSessionState.NotStarted
             && state != ClaudeSessionState.Exited;
@@ -321,7 +320,6 @@ public partial class AiChatControl : UserControl
         if (_session?.IsDangerousMode == true)
             AddSystemMessage("WARNING: Dangerous mode — all permissions auto-approved", isWarning: true);
 
-        // Skip the synthetic "(pending first message)" init fired before the subprocess starts
         if (!string.IsNullOrEmpty(init.Model) && !init.Model.StartsWith("("))
             SessionModelChanged?.Invoke(init.Model);
     }
@@ -331,7 +329,6 @@ public partial class AiChatControl : UserControl
     private void Send_Click(object sender, RoutedEventArgs e) => SendCurrentMessage();
     private async void Stop_Click(object sender, RoutedEventArgs e)
     {
-        // Immediate UI feedback — disable controls, show stopping state
         StopWorkingAnimation();
         StopButton.IsEnabled = false;
         InputBox.IsEnabled = false;
@@ -341,10 +338,10 @@ public partial class AiChatControl : UserControl
 
         RemoveWaitingBubble();
         RemoveInactivityWarning();
-        FinalizeThinkingBlock();
-        FinalizeStreamingBlock();
+        FinalizeThinking();
+        FinalizeStreaming();
+        FinalizeExecution();
 
-        // Await the actual process kill (runs off UI thread)
         var session = _session;
         _session = null;
         if (session != null)
@@ -353,11 +350,10 @@ public partial class AiChatControl : UserControl
             session.Dispose();
         }
 
-        // Now reset to start panel
         ChatPanel.Visibility = Visibility.Collapsed;
         StartPanel.Visibility = Visibility.Visible;
         StopButton.IsEnabled = true;
-        MessageList.Children.Clear();
+        ClearMessages();
     }
 
     private void InputBox_KeyDown(object sender, KeyEventArgs e)
@@ -375,7 +371,6 @@ public partial class AiChatControl : UserControl
     {
         var text = InputBox.Text;
 
-        // Only show popup while typing the command word (starts with /, no whitespace yet)
         if (!text.StartsWith('/') || text.Any(char.IsWhiteSpace))
         {
             SlashCommandPopup.IsOpen = false;
@@ -439,7 +434,6 @@ public partial class AiChatControl : UserControl
 
     private void SlashCommandList_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
-        // Only complete if the click landed on a ListBoxItem (not the empty area or scrollbar)
         var dep = e.OriginalSource as DependencyObject;
         while (dep != null && dep is not ListBoxItem)
             dep = VisualTreeHelper.GetParent(dep);
@@ -465,7 +459,7 @@ public partial class AiChatControl : UserControl
     {
         var menu = new ContextMenu
         {
-            Style = null, // use default WPF style
+            Style = null,
             PlacementTarget = PromptMenuButton,
             Placement = System.Windows.Controls.Primitives.PlacementMode.Top
         };
@@ -504,23 +498,19 @@ public partial class AiChatControl : UserControl
 
         InputBox.Text = "";
 
-        // Check for slash commands
         if (text.StartsWith('/'))
         {
             if (TryHandleLocalCommand(text))
                 return;
-
-            // Not a local command — pass through to Claude Code as-is
         }
 
         if (_session == null || _session.State != ClaudeSessionState.Idle)
             return;
 
-        // Collapse previous streaming block if still open
-        FinalizeStreamingBlock();
-        _executionContentBlock = null;
-        _executionFullText = "";
-        _executionBubble = null;
+        // Defensive turn-boundary finalize — should already have happened on
+        // the previous result, but covers edge cases (manual /compact mid-stream etc.).
+        FinalizeStreaming();
+        FinalizeExecution();
 
         _lastMessageSentTime = DateTime.UtcNow;
         AddUserMessage(text);
@@ -546,7 +536,7 @@ public partial class AiChatControl : UserControl
                 ExecuteLocalCommand("/logs");
                 return true;
             default:
-                return false; // not a local command — pass through
+                return false;
         }
     }
 
@@ -557,19 +547,16 @@ public partial class AiChatControl : UserControl
             case "/clear":
                 if (_session != null && _session.State == ClaudeSessionState.Idle)
                 {
-                    MessageList.Children.Clear();
+                    ClearMessages();
                     AddSystemMessage("Chat cleared.");
                 }
                 break;
 
             case "/compact":
-                // Compact is a Claude Code command — send it through
                 if (_session != null && _session.State == ClaudeSessionState.Idle)
                 {
-                    FinalizeStreamingBlock();
-                    _executionContentBlock = null;
-                    _executionFullText = "";
-                    _executionBubble = null;
+                    FinalizeStreaming();
+                    FinalizeExecution();
                     _lastMessageSentTime = DateTime.UtcNow;
                     AddUserMessage("/compact");
                     ShowWaitingBubble();
@@ -593,69 +580,78 @@ public partial class AiChatControl : UserControl
         }
     }
 
-    // --- Waiting Bubble (shown until first delta arrives) ---
+    // --- Message Collection Helpers ---
+
+    private void AddUserMessage(string text)
+    {
+        Messages.Add(new UserMessage(Guid.NewGuid(), text));
+    }
+
+    private void AddSystemMessage(string text, bool isWarning = false)
+    {
+        Messages.Add(new SystemMessage(Guid.NewGuid(), text, isWarning));
+    }
 
     private void ShowWaitingBubble()
     {
-        var tb = new TextBlock
-        {
-            Text = "Thinking...",
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 11,
-            Foreground = ThemeManager.GetBrush("ChatMutedForeground"),
-            FontStyle = FontStyles.Italic,
-            TextWrapping = TextWrapping.Wrap
-        };
-
-        _waitingBubble = new Border
-        {
-            Background = ThemeManager.GetBrush("ChatThinkingBackground"),
-            CornerRadius = new CornerRadius(6),
-            Padding = new Thickness(8, 4, 8, 4),
-            Margin = new Thickness(8, 2, 40, 2),
-            HorizontalAlignment = HorizontalAlignment.Left,
-            BorderBrush = ThemeManager.GetBrush("ChatThinkingBorderBrush"),
-            BorderThickness = new Thickness(1),
-            Child = tb
-        };
-
-        MessageList.Children.Add(_waitingBubble);
-        ScrollToBottom();
+        if (_waitingVm != null) return; // already shown
+        _waitingVm = new WaitingMessage(Guid.NewGuid());
+        Messages.Add(_waitingVm);
     }
 
     private void RemoveWaitingBubble()
     {
-        if (_waitingBubble != null)
-        {
-            MessageList.Children.Remove(_waitingBubble);
-            _waitingBubble = null;
-        }
+        if (_waitingVm == null) return;
+        Messages.Remove(_waitingVm);
+        _waitingVm = null;
     }
 
-    // --- Content Block Events ---
+    /// <summary>
+    /// Empties the collection and resets every live-tail reference. Used by
+    /// /clear and Stop. Without resetting the refs we'd hold pointers to
+    /// VMs that are no longer in the collection.
+    /// </summary>
+    private void ClearMessages()
+    {
+        _inactivityElapsedTimer?.Stop();
+        _inactivityElapsedTimer = null;
+        // Stop streaming VMs' internal throttle timers and unsubscribe so the
+        // VMs (and this control) become GC-eligible together.
+        if (_streamingVm != null)
+        {
+            _streamingVm.Flush();
+            _streamingVm.PropertyChanged -= OnStreamingTextChanged;
+        }
+        if (_streamingThinkingVm != null)
+        {
+            _streamingThinkingVm.Flush();
+            _streamingThinkingVm.PropertyChanged -= OnStreamingTextChanged;
+        }
+        Messages.Clear();
+        _streamingVm = null;
+        _streamingThinkingVm = null;
+        _executionVm = null;
+        _waitingVm = null;
+        _inactivityVm = null;
+    }
+
+    // --- Content Block / Stream Events ---
 
     private void OnContentBlockStarted(ClaudeContentBlockEvent evt)
     {
         RemoveWaitingBubble();
-
-        // Don't create the thinking bubble eagerly here. claude-opus-4-7 returns
-        // *redacted* thinking blocks — content_block_start fires with type=thinking
-        // but no thinking_delta events ever arrive (only a signature_delta), so an
-        // eagerly-created bubble would stay empty forever. OnThinkingDelta creates
-        // the bubble lazily on the first real delta, so models that do stream
-        // thinking text still get a populated bubble.
+        // Thinking bubble is created lazily on the first real thinking_delta —
+        // claude-opus-4-7 sends redacted thinking (no deltas), so eagerly
+        // creating a bubble here would leave it permanently empty.
     }
 
     private void OnContentBlockStopped(ClaudeContentBlockEvent evt)
     {
-        // When a thinking block stops, collapse it
-        if (_thinkingBlock != null)
-        {
-            FinalizeThinkingBlock();
-        }
+        // The CLI marks the end of a thinking block here. Finalize the live
+        // thinking VM (if any) by swapping it for an immutable record.
+        if (_streamingThinkingVm != null)
+            FinalizeThinking();
     }
-
-    // --- Streaming ---
 
     private void OnStreamDelta(ClaudeStreamDelta delta)
     {
@@ -668,101 +664,97 @@ public partial class AiChatControl : UserControl
             return;
         }
 
-        // First text_delta — collapse any open thinking bubble
-        if (_streamingBlock == null && _thinkingBlock != null)
+        // First text_delta of a new assistant block — finalize any open
+        // thinking first so it renders as a separate (collapsible) message.
+        if (_streamingVm == null && _streamingThinkingVm != null)
+            FinalizeThinking();
+
+        if (_streamingVm == null)
         {
-            FinalizeThinkingBlock();
+            _streamingVm = new StreamingAssistantMessage(Guid.NewGuid());
+            _streamingVm.PropertyChanged += OnStreamingTextChanged;
+            Messages.Add(_streamingVm);
         }
 
-        if (_streamingBlock == null)
-        {
-            // Create a new streaming message block
-            _streamingText = "";
-            _streamingBlock = CreateStreamingBlock();
-            var container = CreateAssistantBubble(_streamingBlock);
-            MessageList.Children.Add(container);
-        }
-
-        _streamingText += delta.Text;
-        _streamingBlock.Text = _streamingText;
-        ScrollToBottom();
+        // Coalesced through a ~30 fps throttle inside the VM so a fast model
+        // stream doesn't flood the binding system.
+        _streamingVm.AppendText(delta.Text);
     }
 
     private void OnThinkingDelta(ClaudeStreamDelta delta)
     {
-        if (_thinkingBlock == null)
+        if (_streamingThinkingVm == null)
         {
-            // No content_block_start arrived — create thinking bubble on first delta
-            _thinkingText = "";
-            _thinkingBlock = CreateSelectableText(11,
-                ThemeManager.GetBrush("ChatMutedForeground"),
-                FontStyles.Italic);
-            _thinkingBubble = CreateThinkingBubble(_thinkingBlock);
-            _thinkingExpanded = true;
-            MessageList.Children.Add(_thinkingBubble);
+            _streamingThinkingVm = new StreamingThinkingMessage(Guid.NewGuid());
+            _streamingThinkingVm.PropertyChanged += OnStreamingTextChanged;
+            Messages.Add(_streamingThinkingVm);
         }
+        _streamingThinkingVm.AppendText(delta.Text);
+    }
 
-        _thinkingText += delta.Text;
-        if (_thinkingExpanded)
-        {
-            _thinkingBlock.Text = _thinkingText;
-        }
-        ScrollToBottom();
+    /// <summary>
+    /// Sticky-bottom follow during streaming: when a live VM's text changes,
+    /// scroll to the new bottom <i>only</i> if the user was already at the
+    /// bottom. If they've scrolled up to read history, don't yank them back.
+    /// </summary>
+    private void OnStreamingTextChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(StreamingTextMessage.Text)) return;
+        var sv = GetScrollViewer();
+        if (sv == null) return;
+        var atBottom = sv.ScrollableHeight == 0 || sv.VerticalOffset >= sv.ScrollableHeight - 50;
+        if (atBottom)
+            Dispatcher.BeginInvoke(() => sv.ScrollToEnd(), DispatcherPriority.Background);
     }
 
     private void OnAssistantMessage(ClaudeAssistantMessage msg)
     {
-        // If we have streaming text, the stream deltas already rendered it.
-        // The assistant message is the "complete" version.
-        // We finalize the streaming block with the full text.
+        // text blocks → finalize the streaming VM with the authoritative full text
         var fullText = string.Join("", msg.Content
             .Where(c => c.Type == "text" && c.Text != null)
             .Select(c => c.Text));
 
-        if (_streamingBlock != null && !string.IsNullOrEmpty(fullText))
-        {
-            _streamingBlock.Text = fullText;
-            _streamingText = fullText;
-        }
+        if (_streamingVm != null && !string.IsNullOrEmpty(fullText))
+            _streamingVm.Text = fullText; // setter clears throttle buffer + timer
 
-        // Group tool-use blocks into collapsible "Execution" bubble
+        // tool_use blocks → append to the building-execution bubble
         var toolBlocks = msg.Content.Where(c => c.Type == "tool_use").ToList();
         if (toolBlocks.Count > 0)
         {
+            EnsureExecutionVm();
             foreach (var block in toolBlocks)
             {
-                var toolText = $"[Tool: {block.Name}]";
+                var inputStr = "";
                 if (block.Input is JsonElement input)
                 {
-                    var inputStr = input.ValueKind == JsonValueKind.Object
+                    inputStr = input.ValueKind == JsonValueKind.Object
                         ? FormatToolInput(input)
                         : input.ToString();
-                    toolText += $"\n{inputStr}";
                 }
-
-                AppendToExecutionBubble(toolText);
+                _executionVm!.Tools.Add(new ToolEntry(block.Name ?? "(unnamed)", inputStr));
             }
         }
 
-        FinalizeStreamingBlock();
+        // The assistant message marks the end of one iteration's text content.
+        // Replace the streaming VM with an immutable AssistantMessage so the
+        // bubble stops re-rendering and (if multi-line) gets the markdown
+        // toggle button.
+        FinalizeStreaming();
     }
 
     private void OnResultReceived(ClaudeResultMessage result)
     {
         RemoveWaitingBubble();
         RemoveInactivityWarning();
-        FinalizeThinkingBlock();
-        FinalizeStreamingBlock();
+        FinalizeThinking();
+        FinalizeStreaming();
+        FinalizeExecution();
 
         if (result.IsError && result.Errors?.Count > 0)
-        {
             AddSystemMessage($"Error: {string.Join("; ", result.Errors)}", isWarning: true);
-        }
 
-        // Update session stats (values from Claude Code are cumulative)
         var (costDelta, tokenDelta) = Stats.Update(result);
 
-        // Build per-interaction summary line using deltas
         var parts = new List<string>();
         if (costDelta > 0)
             parts.Add($"${costDelta:F4}");
@@ -780,67 +772,89 @@ public partial class AiChatControl : UserControl
         SessionStatsChanged?.Invoke(Stats);
     }
 
-    private void FinalizeThinkingBlock()
+    // --- Finalize / Swap (live VM → immutable record) ---
+
+    private void EnsureExecutionVm()
     {
-        if (_thinkingBlock == null || _thinkingBubble == null)
-            return;
-
-        var contentBlock = _thinkingBlock;
-        var fullText = _thinkingText;
-        var expanded = false;
-
-        // Collapse content, add chevron to header
-        _thinkingExpanded = false;
-        contentBlock.Visibility = Visibility.Collapsed;
-
-        var panel = (StackPanel)_thinkingBubble.Child;
-        var label = (UIElement)panel.Children[0];
-        panel.Children.RemoveAt(0);
-
-        var chevron = CreateCollapseChevron(false);
-        var headerRow = new StackPanel { Orientation = Orientation.Horizontal, Cursor = Cursors.Hand };
-        headerRow.Children.Add(chevron);
-        headerRow.Children.Add(label);
-        panel.Children.Insert(0, headerRow);
-
-        headerRow.MouseLeftButtonUp += (_, e) =>
-        {
-            expanded = !expanded;
-            chevron.Text = expanded ? "▼" : "▶";
-            contentBlock.Visibility = expanded ? Visibility.Visible : Visibility.Collapsed;
-            e.Handled = true;
-        };
-
-        _thinkingBlock = null;
-        _thinkingText = "";
-        _thinkingBubble = null;
+        if (_executionVm != null) return;
+        _executionVm = new BuildingExecutionMessage(Guid.NewGuid());
+        Messages.Add(_executionVm);
     }
 
-    private void FinalizeStreamingBlock()
+    private void FinalizeStreaming()
     {
-        if (_streamingBlock == null)
-            return;
+        if (_streamingVm == null) return;
+        // Drain any buffered deltas the throttle timer hasn't flushed yet,
+        // then drop the PropertyChanged subscription so the VM is GC-eligible.
+        _streamingVm.Flush();
+        _streamingVm.PropertyChanged -= OnStreamingTextChanged;
 
-        // Find the parent container and add markdown toggle + collapsible support
-        var parent = _streamingBlock.Parent as StackPanel;
-        if (parent?.Parent is Border border)
+        var idx = Messages.IndexOf(_streamingVm);
+        if (idx >= 0)
         {
-            // Add markdown preview toggle for multi-line assistant messages
-            if (_streamingText.Contains('\n'))
-            {
-                AddMarkdownToggle(border, parent, _streamingBlock, _streamingText);
-            }
-        }
+            var text = _streamingVm.Text;
+            var hasNl = text.Contains('\n');
 
-        _streamingBlock = null;
-        _streamingText = "";
+            // Build the rendered FlowDocument exactly once, here at finalize.
+            // The same document instance is re-attached to whichever container
+            // realizes this message; scroll-past-and-back doesn't re-parse.
+            // Single-line messages render as plain text — markdown rendering
+            // would be no-op and the toggle is useless, so skip the build.
+            FlowDocument? document = null;
+            if (hasNl)
+            {
+                document = MarkdownHelper.BuildDocument(
+                    text,
+                    markdownStyle: (System.Windows.Style)FindResource("ChatMarkdownStyle"),
+                    projectPath: _projectPath,
+                    onFileLinkClicked: p => FileReferenceClicked?.Invoke(p));
+            }
+
+            Messages[idx] = new AssistantMessage(
+                id: _streamingVm.Id,
+                text: text,
+                isMarkdownView: hasNl,
+                hasMarkdownToggle: hasNl,
+                markdown: document);
+        }
+        _streamingVm = null;
+    }
+
+    private void FinalizeThinking()
+    {
+        if (_streamingThinkingVm == null) return;
+        _streamingThinkingVm.Flush();
+        _streamingThinkingVm.PropertyChanged -= OnStreamingTextChanged;
+
+        var idx = Messages.IndexOf(_streamingThinkingVm);
+        if (idx >= 0)
+        {
+            Messages[idx] = new ThinkingMessage(
+                _streamingThinkingVm.Id,
+                _streamingThinkingVm.Text,
+                isExpanded: false);
+        }
+        _streamingThinkingVm = null;
+    }
+
+    private void FinalizeExecution()
+    {
+        if (_executionVm == null) return;
+        var idx = Messages.IndexOf(_executionVm);
+        if (idx >= 0)
+        {
+            Messages[idx] = new ExecutionMessage(
+                _executionVm.Id,
+                _executionVm.Tools.ToList(),
+                isExpanded: false);
+        }
+        _executionVm = null;
     }
 
     // --- Permission Handling ---
 
     private void OnPermissionRequested(ClaudePermissionRequest req)
     {
-        // AskUserQuestion gets a specialized question panel instead of generic Allow/Deny
         if (req.ToolName == "AskUserQuestion" && req.Input.ValueKind == JsonValueKind.Object)
         {
             ShowQuestionPanel(req);
@@ -867,7 +881,6 @@ public partial class AiChatControl : UserControl
         {
             if (!req.Input.TryGetProperty("questions", out var questions) || questions.GetArrayLength() == 0)
             {
-                // Fallback to regular permission panel
                 OnPermissionRequested(new ClaudePermissionRequest
                 {
                     RequestId = req.RequestId,
@@ -937,7 +950,6 @@ public partial class AiChatControl : UserControl
         catch (Exception ex)
         {
             Log.Error("Failed to parse AskUserQuestion input", ex);
-            // Fallback: show as regular permission
             PermissionToolName.Text = $"Tool: {req.ToolName}";
             PermissionDetail.Text = FormatToolInput(req.Input);
             InputPanel.Visibility = Visibility.Collapsed;
@@ -992,99 +1004,33 @@ public partial class AiChatControl : UserControl
 
     private void OnInactivityTimeout()
     {
-        if (_session == null || _inactivityWarning != null)
-            return; // Already showing a warning or no session
+        if (_session == null || _inactivityVm != null)
+            return;
 
-        var elapsed = DateTime.UtcNow - _lastMessageSentTime;
-        var warningText = new TextBlock
+        _inactivityVm = new InactivityWarning(Guid.NewGuid())
         {
-            Text = "Claude hasn't responded for a while — it may be stuck.",
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 11,
-            Foreground = ThemeManager.GetBrush("ChatStatusWarningForeground"),
-            TextWrapping = TextWrapping.Wrap,
-            Margin = new Thickness(0, 0, 0, 4)
+            ElapsedText = FormatElapsed(DateTime.UtcNow - _lastMessageSentTime),
+            OnWait = () =>
+            {
+                RemoveInactivityWarning();
+                _session?.ExtendInactivityTimer();
+            },
+            OnKill = () =>
+            {
+                RemoveInactivityWarning();
+                Stop_Click(this, new RoutedEventArgs());
+            }
         };
+        Messages.Add(_inactivityVm);
 
-        _inactivityElapsedText = new TextBlock
-        {
-            Text = FormatElapsed(elapsed),
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 10,
-            Foreground = ThemeManager.GetBrush("ChatMutedForeground"),
-            Margin = new Thickness(0, 0, 0, 6)
-        };
-
-        // Start a timer to keep the elapsed display up to date
         _inactivityElapsedTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         _inactivityElapsedTimer.Tick += (_, _) =>
         {
-            if (_inactivityElapsedText != null)
-                _inactivityElapsedText.Text = FormatElapsed(DateTime.UtcNow - _lastMessageSentTime);
+            if (_inactivityVm != null)
+                _inactivityVm.ElapsedText = FormatElapsed(DateTime.UtcNow - _lastMessageSentTime);
         };
         _inactivityElapsedTimer.Start();
 
-        var buttonPanel = new StackPanel { Orientation = Orientation.Horizontal };
-
-        var waitBtn = new Button
-        {
-            Content = "Wait longer",
-            Cursor = Cursors.Hand,
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 11,
-            Background = ThemeManager.GetBrush("ChatButtonBackground"),
-            Foreground = ThemeManager.GetBrush("ChatButtonForeground"),
-            BorderBrush = ThemeManager.GetBrush("ChatButtonBorderBrush"),
-            BorderThickness = new Thickness(1),
-            Padding = new Thickness(10, 4, 10, 4),
-            HorizontalAlignment = HorizontalAlignment.Left,
-            Margin = new Thickness(0, 0, 8, 0)
-        };
-        waitBtn.Click += (_, _) =>
-        {
-            RemoveInactivityWarning();
-            _session?.ExtendInactivityTimer();
-        };
-
-        var killBtn = new Button
-        {
-            Content = "Kill process",
-            Cursor = Cursors.Hand,
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 11,
-            Background = ThemeManager.GetBrush("ChatKillButtonBackground"),
-            Foreground = ThemeManager.GetBrush("ChatDangerForeground"),
-            BorderBrush = ThemeManager.GetBrush("ChatKillButtonBorderBrush"),
-            BorderThickness = new Thickness(1),
-            Padding = new Thickness(10, 4, 10, 4),
-            HorizontalAlignment = HorizontalAlignment.Left
-        };
-        killBtn.Click += (_, _) =>
-        {
-            RemoveInactivityWarning();
-            Stop_Click(this, new RoutedEventArgs());
-        };
-
-        buttonPanel.Children.Add(waitBtn);
-        buttonPanel.Children.Add(killBtn);
-
-        var panel = new StackPanel { Margin = new Thickness(0) };
-        panel.Children.Add(warningText);
-        panel.Children.Add(_inactivityElapsedText);
-        panel.Children.Add(buttonPanel);
-
-        _inactivityWarning = new Border
-        {
-            Background = ThemeManager.GetBrush("ChatWarningBackground"),
-            CornerRadius = new CornerRadius(6),
-            Padding = new Thickness(10, 8, 10, 8),
-            Margin = new Thickness(8, 4, 8, 4),
-            BorderBrush = ThemeManager.GetBrush("ChatWarningBorderBrush"),
-            BorderThickness = new Thickness(1),
-            Child = panel
-        };
-
-        MessageList.Children.Add(_inactivityWarning);
         ScrollToBottom();
     }
 
@@ -1099,11 +1045,10 @@ public partial class AiChatControl : UserControl
     {
         _inactivityElapsedTimer?.Stop();
         _inactivityElapsedTimer = null;
-        _inactivityElapsedText = null;
-        if (_inactivityWarning != null)
+        if (_inactivityVm != null)
         {
-            MessageList.Children.Remove(_inactivityWarning);
-            _inactivityWarning = null;
+            Messages.Remove(_inactivityVm);
+            _inactivityVm = null;
         }
     }
 
@@ -1111,7 +1056,6 @@ public partial class AiChatControl : UserControl
 
     private void OnErrorOutput(string text)
     {
-        // Only show meaningful errors, not debug noise
         if (text.Contains("error", StringComparison.OrdinalIgnoreCase) ||
             text.Contains("fatal", StringComparison.OrdinalIgnoreCase))
         {
@@ -1122,344 +1066,169 @@ public partial class AiChatControl : UserControl
     private void OnProcessExited(int exitCode)
     {
         if (exitCode != 0)
-        {
             AddSystemMessage($"Claude process exited with code {exitCode}", isWarning: true);
-        }
         else
-        {
             AddSystemMessage("Session ended");
+    }
+
+    // --- DataTemplate Click Handlers ---
+
+    // For finalized AssistantMessage: toggling the source/rendered view replaces
+    // the immutable VM with a new instance carrying the flipped flag. The
+    // ItemsControl re-evaluates the ContentControl's ContentTemplate selector
+    // and swaps just that one container's child template.
+    private void MarkdownToggle_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement fe && fe.Tag is AssistantMessage msg)
+        {
+            var idx = Messages.IndexOf(msg);
+            if (idx >= 0)
+            {
+                // Reuse the same FlowDocument — toggling the view doesn't
+                // re-parse markdown.
+                Messages[idx] = new AssistantMessage(
+                    msg.Id, msg.Text, !msg.IsMarkdownView, msg.HasMarkdownToggle, msg.Markdown);
+            }
         }
     }
 
-    // --- Message Rendering ---
-
-    private void AddUserMessage(string text)
+    private void ThinkingHeader_Click(object sender, MouseButtonEventArgs e)
     {
-        var bubble = new Border
+        if (sender is FrameworkElement fe && fe.Tag is ThinkingMessage msg)
         {
-            Background = ThemeManager.GetBrush("ChatUserBubbleBackground"),
-            CornerRadius = new CornerRadius(8, 8, 2, 8),
-            Padding = new Thickness(10, 6, 10, 6),
-            Margin = new Thickness(40, 4, 8, 4),
-            HorizontalAlignment = HorizontalAlignment.Right
-        };
-
-        var panel = new StackPanel();
-        var label = new TextBlock
-        {
-            Text = "You",
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 10,
-            Foreground = ThemeManager.GetBrush("ChatUserLabelForeground"),
-            Margin = new Thickness(0, 0, 0, 2)
-        };
-        var content = CreateSelectableText(12,
-            ThemeManager.GetBrush("ChatTextForeground"));
-        content.Text = text;
-        panel.Children.Add(label);
-        panel.Children.Add(content);
-        bubble.Child = panel;
-
-        MessageList.Children.Add(bubble);
-        ScrollToBottom();
+            var idx = Messages.IndexOf(msg);
+            if (idx >= 0)
+                Messages[idx] = new ThinkingMessage(msg.Id, msg.Text, !msg.IsExpanded);
+        }
+        e.Handled = true;
     }
 
-    private Border CreateAssistantBubble(TextBox contentBlock)
+    private void ExecutionHeader_Click(object sender, MouseButtonEventArgs e)
     {
-        var bubble = new Border
+        if (sender is FrameworkElement fe && fe.Tag is ExecutionMessage msg)
         {
-            Background = ThemeManager.GetBrush("ChatAssistantBubbleBackground"),
-            CornerRadius = new CornerRadius(8, 8, 8, 2),
-            Padding = new Thickness(10, 6, 10, 6),
-            Margin = new Thickness(8, 4, 40, 4),
-            HorizontalAlignment = HorizontalAlignment.Left
-        };
-
-        var panel = new StackPanel();
-        var label = new TextBlock
-        {
-            Text = "Claude",
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 10,
-            Foreground = ThemeManager.GetBrush("ChatAssistantLabelForeground"),
-            Margin = new Thickness(0, 0, 0, 2)
-        };
-        panel.Children.Add(label);
-        panel.Children.Add(contentBlock);
-        bubble.Child = panel;
-
-        return bubble;
+            var idx = Messages.IndexOf(msg);
+            if (idx >= 0)
+                Messages[idx] = new ExecutionMessage(msg.Id, msg.Tools, !msg.IsExpanded);
+        }
+        e.Handled = true;
     }
 
-    private static TextBox CreateStreamingBlock()
+    private void BuildingExecutionHeader_Click(object sender, MouseButtonEventArgs e)
     {
-        return CreateSelectableText(12,
-            ThemeManager.GetBrush("ChatTextForeground"));
+        if (sender is FrameworkElement fe && fe.Tag is BuildingExecutionMessage msg)
+            msg.IsExpanded = !msg.IsExpanded;
+        e.Handled = true;
     }
 
-    private static Border CreateThinkingBubble(TextBox contentBlock)
+    private void InactivityWait_Click(object sender, RoutedEventArgs e)
     {
-        var bubble = new Border
-        {
-            Background = ThemeManager.GetBrush("ChatThinkingBackground"),
-            CornerRadius = new CornerRadius(6),
-            Padding = new Thickness(8, 4, 8, 4),
-            Margin = new Thickness(8, 2, 40, 2),
-            HorizontalAlignment = HorizontalAlignment.Left,
-            BorderBrush = ThemeManager.GetBrush("ChatThinkingBorderBrush"),
-            BorderThickness = new Thickness(1)
-        };
-
-        var panel = new StackPanel();
-        var label = new TextBlock
-        {
-            Text = "Thinking",
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 10,
-            Foreground = ThemeManager.GetBrush("ChatSubtleForeground"),
-            FontStyle = FontStyles.Italic,
-            Margin = new Thickness(0, 0, 0, 2)
-        };
-        panel.Children.Add(label);
-        panel.Children.Add(contentBlock);
-        bubble.Child = panel;
-
-        return bubble;
+        if (sender is FrameworkElement fe && fe.Tag is InactivityWarning msg)
+            msg.OnWait?.Invoke();
     }
 
-    private void AppendToExecutionBubble(string toolText)
+    private void InactivityKill_Click(object sender, RoutedEventArgs e)
     {
-        if (_executionBubble == null)
+        if (sender is FrameworkElement fe && fe.Tag is InactivityWarning msg)
+            msg.OnKill?.Invoke();
+    }
+
+    // Container recycling: DataContext changes when the container is reused
+    // for a different message. Attach the cached FlowDocument — no re-parse,
+    // no re-wire of file links.
+    private void AssistantMarkdown_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        => AttachAssistantDocument((MarkdownScrollViewer)sender, e.NewValue as AssistantMessage);
+
+    // Initial realization — DataContextChanged may fire before the viewer is
+    // in the visual tree, so attach again here defensively.
+    private void AssistantMarkdown_Loaded(object sender, RoutedEventArgs e)
+        => AttachAssistantDocument((MarkdownScrollViewer)sender, ((MarkdownScrollViewer)sender).DataContext as AssistantMessage);
+
+    private static void AttachAssistantDocument(MarkdownScrollViewer viewer, AssistantMessage? msg)
+    {
+        if (msg?.Markdown == null)
         {
-            _executionContentBlock = CreateSelectableText(10,
-                ThemeManager.GetBrush("ChatExecutionForeground"),
-                FontStyles.Normal);
-            _executionBubble = CreateExecutionBubble(_executionContentBlock);
-            MessageList.Children.Add(_executionBubble);
-            _executionFullText = "";
+            viewer.Document = null;
+            return;
+        }
+        if (ReferenceEquals(viewer.Document, msg.Markdown))
+            return;
+
+        // FlowDocument has at most one logical parent. If our cached document
+        // is currently attached to another (recycled) viewer, detach it first.
+        if (msg.Markdown.Parent is System.Windows.Controls.FlowDocumentScrollViewer prev
+            && !ReferenceEquals(prev, viewer))
+        {
+            prev.Document = null;
         }
 
-        _executionFullText += (string.IsNullOrEmpty(_executionFullText) ? "" : "\n\n") + toolText;
-        _executionContentBlock!.Text = _executionFullText;
-        ScrollToBottom();
+        viewer.Document = msg.Markdown;
     }
 
-    private static Border CreateExecutionBubble(TextBox contentBlock)
+    // --- Scroll + Wheel ---
+
+    private ScrollViewer? GetScrollViewer()
     {
-        var bubble = new Border
-        {
-            Background = ThemeManager.GetBrush("ChatExecutionBackground"),
-            CornerRadius = new CornerRadius(6),
-            Padding = new Thickness(8, 4, 8, 4),
-            Margin = new Thickness(8, 2, 40, 2),
-            HorizontalAlignment = HorizontalAlignment.Left,
-            BorderBrush = ThemeManager.GetBrush("ChatExecutionBorderBrush"),
-            BorderThickness = new Thickness(1)
-        };
-
-        var panel = new StackPanel();
-
-        var label = new TextBlock
-        {
-            Text = "Execution",
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 10,
-            Foreground = ThemeManager.GetBrush("ChatExecutionForeground"),
-            FontStyle = FontStyles.Italic,
-            Margin = new Thickness(0, 0, 0, 2)
-        };
-
-        var chevron = CreateCollapseChevron(false);
-        var headerRow = new StackPanel { Orientation = Orientation.Horizontal, Cursor = Cursors.Hand };
-        headerRow.Children.Add(chevron);
-        headerRow.Children.Add(label);
-
-        contentBlock.Visibility = Visibility.Collapsed;
-        var expanded = false;
-
-        headerRow.MouseLeftButtonUp += (_, e) =>
-        {
-            expanded = !expanded;
-            chevron.Text = expanded ? "▼" : "▶";
-            contentBlock.Visibility = expanded ? Visibility.Visible : Visibility.Collapsed;
-            e.Handled = true;
-        };
-
-        panel.Children.Add(headerRow);
-        panel.Children.Add(contentBlock);
-        bubble.Child = panel;
-
-        return bubble;
+        if (_scrollViewer != null) return _scrollViewer;
+        _scrollViewer = FindVisualChild<ScrollViewer>(MessageList);
+        return _scrollViewer;
     }
 
-    private void AddSystemMessage(string text, bool isWarning = false)
+    private static T? FindVisualChild<T>(DependencyObject root) where T : DependencyObject
     {
-        var tb = new TextBlock
+        if (root is T match) return match;
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
         {
-            Text = text,
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 10,
-            Foreground = isWarning
-                ? ThemeManager.GetBrush("ChatDangerForeground")
-                : ThemeManager.GetBrush("ChatSubtleForeground"),
-            HorizontalAlignment = HorizontalAlignment.Center,
-            TextWrapping = TextWrapping.Wrap,
-            Margin = new Thickness(8, 6, 8, 6)
-        };
-
-        MessageList.Children.Add(tb);
-        ScrollToBottom();
+            var found = FindVisualChild<T>(VisualTreeHelper.GetChild(root, i));
+            if (found != null) return found;
+        }
+        return null;
     }
 
-    // --- Markdown Toggle + Collapsible Messages ---
-
-    private void AddMarkdownToggle(Border bubble, StackPanel panel, TextBox contentBlock, string fullText)
+    private void ScrollToBottom()
     {
-        // Create the markdown rendered view
-        var markdownViewer = new MarkdownScrollViewer
-        {
-            Background = Brushes.Transparent,
-            Foreground = ThemeManager.GetBrush("ChatTextForeground"),
-            MarkdownStyle = (Style)FindResource("ChatMarkdownStyle"),
-            VerticalScrollBarVisibility = ScrollBarVisibility.Disabled,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
-            Padding = new Thickness(0)
-        };
-        var linkified = MarkdownHelper.LinkifyPaths(fullText, _projectPath);
-        MarkdownHelper.RenderTo(markdownViewer, linkified);
-        MarkdownHelper.WireFileLinks(markdownViewer.Document,
-            path => FileReferenceClicked?.Invoke(path));
-
-        var isRendered = true;
-        contentBlock.Visibility = Visibility.Collapsed;
-        panel.Children.Add(markdownViewer);
-
-        // Toggle button (top-right of bubble)
-        var toggleIcon = new TextBlock
-        {
-            Text = "\uE943", // Code icon (showing rendered, click to see source)
-            FontFamily = new FontFamily("Segoe MDL2 Assets"),
-            FontSize = 11,
-            Foreground = ThemeManager.GetBrush("ChatMutedForeground")
-        };
-
-        var toggleButton = new Button
-        {
-            Content = toggleIcon,
-            Background = Brushes.Transparent,
-            BorderBrush = ThemeManager.GetBrush("ChatThinkingBorderBrush"),
-            BorderThickness = new Thickness(1),
-            Cursor = Cursors.Hand,
-            Padding = new Thickness(4, 2, 4, 2),
-            HorizontalAlignment = HorizontalAlignment.Right,
-            ToolTip = "Switch to source view",
-            Opacity = 0.7
-        };
-
-        // Remove default button chrome
-        var btnTemplate = new ControlTemplate(typeof(Button));
-        var bdFactory = new FrameworkElementFactory(typeof(Border), "Bd");
-        bdFactory.SetValue(Border.BackgroundProperty, new TemplateBindingExtension(BackgroundProperty));
-        bdFactory.SetValue(Border.BorderBrushProperty, new TemplateBindingExtension(BorderBrushProperty));
-        bdFactory.SetValue(Border.BorderThicknessProperty, new TemplateBindingExtension(BorderThicknessProperty));
-        bdFactory.SetValue(Border.CornerRadiusProperty, new CornerRadius(3));
-        bdFactory.SetValue(Border.PaddingProperty, new TemplateBindingExtension(PaddingProperty));
-        var cp = new FrameworkElementFactory(typeof(ContentPresenter));
-        cp.SetValue(ContentPresenter.HorizontalAlignmentProperty, HorizontalAlignment.Center);
-        cp.SetValue(ContentPresenter.VerticalAlignmentProperty, VerticalAlignment.Center);
-        bdFactory.AppendChild(cp);
-        btnTemplate.VisualTree = bdFactory;
-        toggleButton.Template = btnTemplate;
-
-        toggleButton.Click += (_, _) =>
-        {
-            if (isRendered)
-            {
-                markdownViewer.Visibility = Visibility.Collapsed;
-                contentBlock.Visibility = Visibility.Visible;
-                toggleIcon.Text = "\uE890"; // Preview/eye icon
-                toggleButton.ToolTip = "Switch to rendered view";
-                isRendered = false;
-            }
-            else
-            {
-                contentBlock.Visibility = Visibility.Collapsed;
-                markdownViewer.Visibility = Visibility.Visible;
-                toggleIcon.Text = "\uE943"; // Code icon
-                toggleButton.ToolTip = "Switch to source view";
-                isRendered = true;
-            }
-        };
-
-        // Insert toggle button at the top of the panel (after label)
-        panel.Children.Insert(1, toggleButton);
+        var sv = GetScrollViewer();
+        if (sv != null)
+            sv.ScrollToEnd();
     }
 
-    private void MakeCollapsible(Border bubble, StackPanel panel, TextBox contentBlock, string fullText)
+    /// <summary>
+    /// Sticky-bottom auto-scroll: when a message is added and the user is at
+    /// (or near) the bottom of the chat, scroll to follow. If they've scrolled
+    /// up to read history, leave them where they are.
+    /// </summary>
+    private void OnMessagesChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        var lines = fullText.Split('\n');
-        if (lines.Length <= 3)
-            return; // Not worth collapsing
+        if (e.Action != NotifyCollectionChangedAction.Add)
+            return;
 
-        var firstLine = lines[0].Length > 80 ? lines[0][..80] + "..." : lines[0];
-        var collapsed = $"{firstLine}\n  [{lines.Length} lines]";
-
-        // Add chevron to the header row next to the label
-        var isExpanded = true;
-        var label = (UIElement)panel.Children[0];
-        panel.Children.RemoveAt(0);
-
-        var chevron = CreateCollapseChevron(true);
-        var headerRow = new StackPanel { Orientation = Orientation.Horizontal, Cursor = Cursors.Hand };
-        headerRow.Children.Add(chevron);
-        headerRow.Children.Add(label);
-        panel.Children.Insert(0, headerRow);
-
-        headerRow.MouseLeftButtonUp += (_, e) =>
+        var sv = GetScrollViewer();
+        if (sv == null)
         {
-            isExpanded = !isExpanded;
-            chevron.Text = isExpanded ? "▼" : "▶";
-            contentBlock.Text = isExpanded ? fullText : collapsed;
-            e.Handled = true;
-        };
+            // Template not applied yet — schedule scroll after first render.
+            Dispatcher.BeginInvoke(ScrollToBottom, DispatcherPriority.Loaded);
+            return;
+        }
+
+        var atBottom = sv.ScrollableHeight == 0
+            || sv.VerticalOffset >= sv.ScrollableHeight - 50;
+        if (atBottom)
+        {
+            // Defer until after the new container is realized & measured.
+            Dispatcher.BeginInvoke(() => sv.ScrollToEnd(), DispatcherPriority.Background);
+        }
+    }
+
+    private void MessageList_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        var sv = GetScrollViewer();
+        if (sv == null) return;
+        sv.ScrollToVerticalOffset(sv.VerticalOffset - e.Delta);
+        e.Handled = true;
     }
 
     // --- Helpers ---
-
-    private static TextBlock CreateCollapseChevron(bool expanded)
-    {
-        return new TextBlock
-        {
-            Text = expanded ? "▼" : "▶",
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = 10,
-            Foreground = ThemeManager.GetBrush("ChatMutedForeground"),
-            Cursor = Cursors.Hand,
-            Margin = new Thickness(0, 0, 4, 0),
-            VerticalAlignment = VerticalAlignment.Center
-        };
-    }
-
-    private static TextBox CreateSelectableText(double fontSize, Brush foreground,
-        FontStyle? fontStyle = null)
-    {
-        var tb = new TextBox
-        {
-            FontFamily = new FontFamily("Cascadia Code, Consolas, Courier New"),
-            FontSize = fontSize,
-            Foreground = foreground,
-            TextWrapping = TextWrapping.Wrap,
-            IsReadOnly = true,
-            BorderThickness = new Thickness(0),
-            Background = Brushes.Transparent,
-            Padding = new Thickness(0),
-            FocusVisualStyle = null,
-            VerticalScrollBarVisibility = ScrollBarVisibility.Disabled
-        };
-        if (fontStyle.HasValue)
-            tb.FontStyle = fontStyle.Value;
-        return tb;
-    }
 
     private static string FormatToolInput(JsonElement input)
     {
@@ -1471,17 +1240,5 @@ public partial class AiChatControl : UserControl
         {
             return input.ToString();
         }
-    }
-
-    private void MessageScroller_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
-    {
-        // Prevent child controls (TextBox, MarkdownScrollViewer) from stealing wheel events
-        MessageScroller.ScrollToVerticalOffset(MessageScroller.VerticalOffset - e.Delta);
-        e.Handled = true;
-    }
-
-    private void ScrollToBottom()
-    {
-        MessageScroller.ScrollToEnd();
     }
 }

--- a/src/AgentDock/Controls/AiChatControl.xaml.cs
+++ b/src/AgentDock/Controls/AiChatControl.xaml.cs
@@ -64,6 +64,12 @@ public partial class AiChatControl : UserControl
     public event Action<string>? SessionModelChanged;
 
     /// <summary>
+    /// Raised when the user clicks a file-path reference rendered inside an
+    /// assistant markdown bubble. Payload is the absolute path.
+    /// </summary>
+    public event Action<string>? FileReferenceClicked;
+
+    /// <summary>
     /// Cumulative stats for the current session.
     /// </summary>
     public SessionStats Stats { get; } = new();
@@ -1249,7 +1255,10 @@ public partial class AiChatControl : UserControl
             HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
             Padding = new Thickness(0)
         };
-        MarkdownHelper.RenderTo(markdownViewer, fullText);
+        var linkified = MarkdownHelper.LinkifyPaths(fullText, _projectPath);
+        MarkdownHelper.RenderTo(markdownViewer, linkified);
+        MarkdownHelper.WireFileLinks(markdownViewer.Document,
+            path => FileReferenceClicked?.Invoke(path));
 
         var isRendered = true;
         contentBlock.Visibility = Visibility.Collapsed;

--- a/src/AgentDock/Controls/FileExplorerControl.xaml
+++ b/src/AgentDock/Controls/FileExplorerControl.xaml
@@ -99,6 +99,7 @@
             <TreeView.ItemContainerStyle>
                 <Style TargetType="TreeViewItem">
                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
+                    <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
                     <Setter Property="Background" Value="Transparent" />
                     <Setter Property="Foreground" Value="{DynamicResource ExplorerForeground}" />
                     <Setter Property="Padding" Value="2,0" />

--- a/src/AgentDock/Controls/FileExplorerControl.xaml.cs
+++ b/src/AgentDock/Controls/FileExplorerControl.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using AgentDock.Models;
 using AgentDock.Services;
 
@@ -72,6 +73,97 @@ public partial class FileExplorerControl : UserControl
     /// Gets the folder name for use in panel titles.
     /// </summary>
     public string FolderName => Path.GetFileName(_rootPath) ?? _rootPath;
+
+    /// <summary>
+    /// Expands the tree to <paramref name="absolutePath"/>, selects the matching node,
+    /// and raises <see cref="FileSelected"/> if it's a file. The path must be inside
+    /// the loaded root and exist on disk; otherwise this is a no-op.
+    /// </summary>
+    public void RevealAndSelect(string absolutePath)
+    {
+        if (string.IsNullOrEmpty(_rootPath) || string.IsNullOrEmpty(absolutePath))
+            return;
+
+        string rootFull, targetFull;
+        try
+        {
+            rootFull = Path.GetFullPath(_rootPath);
+            targetFull = Path.GetFullPath(absolutePath);
+        }
+        catch { return; }
+
+        if (!File.Exists(targetFull) && !Directory.Exists(targetFull))
+            return;
+
+        if (!targetFull.StartsWith(rootFull, StringComparison.OrdinalIgnoreCase))
+            return;
+        if (targetFull.Length == rootFull.Length)
+            return; // path is the root itself
+
+        var relative = Path.GetRelativePath(rootFull, targetFull);
+        var segments = relative.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0) return;
+
+        IEnumerable<FileNode> currentLevel = FileTree.Items.OfType<FileNode>();
+        FileNode? targetNode = null;
+
+        for (var i = 0; i < segments.Length; i++)
+        {
+            var match = currentLevel.FirstOrDefault(n =>
+                string.Equals(n.Name, segments[i], StringComparison.OrdinalIgnoreCase));
+            if (match == null) return;
+
+            var isLast = i == segments.Length - 1;
+            if (!isLast)
+            {
+                if (!match.IsDirectory) return;
+                if (match.Children.Count == 1 && match.Children[0].FullPath == null)
+                    LoadChildren(match);
+                match.IsExpanded = true;
+                match.Icon = "📂"; // open folder
+                currentLevel = match.Children;
+            }
+            else
+            {
+                targetNode = match;
+            }
+        }
+
+        if (targetNode == null) return;
+
+        targetNode.IsSelected = true;
+
+        // Scroll the materialized container into view once the TreeView has caught up.
+        var captured = targetNode;
+        Dispatcher.BeginInvoke(() => BringNodeIntoView(captured), DispatcherPriority.Background);
+
+        if (!targetNode.IsDirectory && targetNode.FullPath != null)
+            FileSelected?.Invoke(targetNode.FullPath);
+    }
+
+    private void BringNodeIntoView(FileNode node)
+    {
+        var tvi = FindContainer(FileTree, FileTree.Items, node);
+        tvi?.BringIntoView();
+    }
+
+    private static TreeViewItem? FindContainer(ItemsControl parent, ItemCollection items, FileNode target)
+    {
+        foreach (var obj in items)
+        {
+            if (parent.ItemContainerGenerator.ContainerFromItem(obj) is not TreeViewItem tvi)
+                continue;
+            if (ReferenceEquals(obj, target))
+                return tvi;
+            if (obj is FileNode n && n.IsDirectory && n.IsExpanded)
+            {
+                var found = FindContainer(tvi, tvi.Items, target);
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
 
     /// <summary>
     /// Refreshes the file tree while preserving expanded folder state.
@@ -427,6 +519,7 @@ public class FileNode : INotifyPropertyChanged
     private string _icon = "";
     private string _name = "";
     private bool _isExpanded;
+    private bool _isSelected;
 
     public string Name
     {
@@ -455,6 +548,12 @@ public class FileNode : INotifyPropertyChanged
     {
         get => _isExpanded;
         set { _isExpanded = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsExpanded))); }
+    }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set { _isSelected = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected))); }
     }
 
     public ObservableCollection<FileNode> Children { get; } = [];

--- a/src/AgentDock/Controls/FilePreviewControl.xaml
+++ b/src/AgentDock/Controls/FilePreviewControl.xaml
@@ -74,6 +74,22 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
                     Margin="0,6,6,0">
+            <Button x:Name="RevealInExplorerButton"
+                    Visibility="Collapsed"
+                    Click="RevealInExplorer_Click"
+                    Padding="6,4"
+                    Cursor="Hand"
+                    ToolTip="Show full file (reveal in File Explorer)"
+                    Background="{DynamicResource PreviewBackground}"
+                    BorderBrush="{DynamicResource PreviewLineNumberForeground}"
+                    BorderThickness="1"
+                    Opacity="0.85"
+                    Margin="0,0,4,0">
+                <TextBlock Text="&#xE8A5;"
+                           FontFamily="Segoe MDL2 Assets"
+                           FontSize="14"
+                           Foreground="{DynamicResource PreviewForeground}" />
+            </Button>
             <Button x:Name="MarkdownToggleButton"
                     Visibility="Collapsed"
                     Click="MarkdownToggle_Click"

--- a/src/AgentDock/Controls/FilePreviewControl.xaml.cs
+++ b/src/AgentDock/Controls/FilePreviewControl.xaml.cs
@@ -27,6 +27,11 @@ public partial class FilePreviewControl : UserControl
         ".md", ".markdown"
     };
 
+    private static readonly HashSet<string> JsonExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".json"
+    };
+
     // Max file size to preview (5 MB)
     private const long MaxTextFileSize = 5 * 1024 * 1024;
 
@@ -44,8 +49,12 @@ public partial class FilePreviewControl : UserControl
     {
         ApplyLinkColor();
 
-        // Re-apply syntax highlighting with new theme colors
-        if (_currentExtension != null && TextPreview.Visibility == Visibility.Visible && _diffColorizer == null)
+        // Re-apply syntax highlighting with new theme colors. JSON keeps no built-in
+        // highlighter — the JsonColorizer picks up theme brushes on Redraw below.
+        if (_currentExtension != null
+            && TextPreview.Visibility == Visibility.Visible
+            && _diffColorizer == null
+            && !JsonExtensions.Contains(_currentExtension))
         {
             TextPreview.SyntaxHighlighting = ThemeManager.GetHighlighting(_currentExtension);
         }
@@ -68,6 +77,7 @@ public partial class FilePreviewControl : UserControl
     }
 
     private MarkdownLinkColorizer? _linkColorizer;
+    private JsonColorizer? _jsonColorizer;
 
     private void ApplyMarkdownLinkColorizer(string extension)
     {
@@ -86,6 +96,26 @@ public partial class FilePreviewControl : UserControl
         {
             TextPreview.TextArea.TextView.LineTransformers.Remove(_linkColorizer);
             _linkColorizer = null;
+        }
+    }
+
+    private void ApplyJsonColorizer(string extension)
+    {
+        RemoveJsonColorizer();
+
+        if (JsonExtensions.Contains(extension))
+        {
+            _jsonColorizer = new JsonColorizer();
+            TextPreview.TextArea.TextView.LineTransformers.Add(_jsonColorizer);
+        }
+    }
+
+    private void RemoveJsonColorizer()
+    {
+        if (_jsonColorizer != null)
+        {
+            TextPreview.TextArea.TextView.LineTransformers.Remove(_jsonColorizer);
+            _jsonColorizer = null;
         }
     }
 
@@ -271,8 +301,13 @@ public partial class FilePreviewControl : UserControl
 
             TextPreview.Load(filePath);
             _currentExtension = extension;
-            TextPreview.SyntaxHighlighting = ThemeManager.GetHighlighting(extension);
+            // JSON is rendered by JsonColorizer instead of any built-in highlighter,
+            // so colors stay theme-aware in both dark and light modes.
+            TextPreview.SyntaxHighlighting = JsonExtensions.Contains(extension)
+                ? null
+                : ThemeManager.GetHighlighting(extension);
             ApplyMarkdownLinkColorizer(extension);
+            ApplyJsonColorizer(extension);
             TextPreview.ScrollToHome();
             TextPreview.Visibility = Visibility.Visible;
         }
@@ -332,6 +367,7 @@ public partial class FilePreviewControl : UserControl
         _isMarkdownRendered = false;
         RemoveDiffColorizer();
         RemoveMarkdownLinkColorizer();
+        RemoveJsonColorizer();
     }
 
     private void RemoveDiffColorizer()

--- a/src/AgentDock/Controls/FilePreviewControl.xaml.cs
+++ b/src/AgentDock/Controls/FilePreviewControl.xaml.cs
@@ -37,6 +37,13 @@ public partial class FilePreviewControl : UserControl
 
     private string? _currentExtension;
     private bool _isMarkdownRendered;
+    private string? _diffFilePath;
+
+    /// <summary>
+    /// Raised when the user clicks the "show full file" button while a diff is being
+    /// previewed. Payload is the absolute file path passed to <see cref="ShowDiff"/>.
+    /// </summary>
+    public event Action<string>? RevealInExplorerRequested;
 
     public FilePreviewControl()
     {
@@ -152,7 +159,7 @@ public partial class FilePreviewControl : UserControl
 
     private DiffLineColorizer? _diffColorizer;
 
-    public void ShowDiff(string diffContent)
+    public void ShowDiff(string filePath, string diffContent)
     {
         HideAll();
         ClosePreviewButton.Visibility = Visibility.Visible;
@@ -167,7 +174,18 @@ public partial class FilePreviewControl : UserControl
         _diffColorizer = new DiffLineColorizer();
         TextPreview.TextArea.TextView.LineTransformers.Add(_diffColorizer);
 
+        _diffFilePath = filePath;
+        RevealInExplorerButton.Visibility = File.Exists(filePath)
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
         TextPreview.Visibility = Visibility.Visible;
+    }
+
+    private void RevealInExplorer_Click(object sender, RoutedEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(_diffFilePath))
+            RevealInExplorerRequested?.Invoke(_diffFilePath);
     }
 
     public void Clear()
@@ -361,10 +379,12 @@ public partial class FilePreviewControl : UserControl
         TextPreview.Visibility = Visibility.Collapsed;
         MarkdownPreview.Visibility = Visibility.Collapsed;
         MarkdownToggleButton.Visibility = Visibility.Collapsed;
+        RevealInExplorerButton.Visibility = Visibility.Collapsed;
         ClosePreviewButton.Visibility = Visibility.Collapsed;
         ImageContainer.Visibility = Visibility.Collapsed;
         NoPreviewMessage.Visibility = Visibility.Collapsed;
         _isMarkdownRendered = false;
+        _diffFilePath = null;
         RemoveDiffColorizer();
         RemoveMarkdownLinkColorizer();
         RemoveJsonColorizer();

--- a/src/AgentDock/Controls/GitStatusControl.xaml.cs
+++ b/src/AgentDock/Controls/GitStatusControl.xaml.cs
@@ -73,6 +73,10 @@ public partial class GitStatusControl : UserControl
                              | NotifyFilters.DirectoryName
                              | NotifyFilters.LastWrite
                              | NotifyFilters.Size,
+                // Default is 8 KB, which overflows on busy repos (node_modules installs,
+                // build output) and drops events with "Too many changes at once". 64 KB
+                // is the practical ceiling for non-paged pool usage on most systems.
+                InternalBufferSize = 64 * 1024,
                 EnableRaisingEvents = true
             };
 

--- a/src/AgentDock/Controls/JsonColorizer.cs
+++ b/src/AgentDock/Controls/JsonColorizer.cs
@@ -1,0 +1,81 @@
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Media;
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Rendering;
+
+namespace AgentDock.Controls;
+
+/// <summary>
+/// Lightweight JSON syntax colorizer. Distinguishes object keys from string values,
+/// numbers, booleans, null, and punctuation using theme-aware brushes.
+/// </summary>
+public partial class JsonColorizer : DocumentColorizingTransformer
+{
+    // Strings (with escapes), numbers, keywords, punctuation — single pass, ordered so
+    // strings are matched first so their content isn't tokenized as keywords.
+    [GeneratedRegex(
+        @"(?<str>""(?:\\.|[^""\\])*"")|(?<kw>\b(?:true|false|null)\b)|(?<num>-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|(?<punct>[\{\}\[\],:])",
+        RegexOptions.Compiled)]
+    private static partial Regex Tokens();
+
+    protected override void ColorizeLine(DocumentLine line)
+    {
+        if (line.Length == 0)
+            return;
+
+        var keyBrush = GetBrush("JsonKeyForeground");
+        var stringBrush = GetBrush("JsonStringForeground");
+        var numberBrush = GetBrush("JsonNumberForeground");
+        var booleanBrush = GetBrush("JsonBooleanForeground");
+        var nullBrush = GetBrush("JsonNullForeground");
+        var punctuationBrush = GetBrush("JsonPunctuationForeground");
+
+        var text = CurrentContext.Document.GetText(line);
+
+        foreach (Match match in Tokens().Matches(text))
+        {
+            Brush? brush = null;
+
+            if (match.Groups["str"].Success)
+            {
+                // Key if the next non-whitespace character on this line is ':'
+                var afterEnd = match.Index + match.Length;
+                var isKey = false;
+                for (int i = afterEnd; i < text.Length; i++)
+                {
+                    if (text[i] == ':') { isKey = true; break; }
+                    if (!char.IsWhiteSpace(text[i])) break;
+                }
+                brush = isKey ? keyBrush : stringBrush;
+            }
+            else if (match.Groups["kw"].Success)
+            {
+                brush = match.Value == "null" ? nullBrush : booleanBrush;
+            }
+            else if (match.Groups["num"].Success)
+            {
+                brush = numberBrush;
+            }
+            else if (match.Groups["punct"].Success)
+            {
+                brush = punctuationBrush;
+            }
+
+            if (brush == null)
+                continue;
+
+            var start = line.Offset + match.Index;
+            var end = start + match.Length;
+            ChangeLinePart(start, end, element =>
+            {
+                element.TextRunProperties.SetForegroundBrush(brush);
+            });
+        }
+    }
+
+    private static Brush? GetBrush(string resourceKey)
+    {
+        return Application.Current.TryFindResource(resourceKey) as Brush;
+    }
+}

--- a/src/AgentDock/MainWindow.xaml
+++ b/src/AgentDock/MainWindow.xaml
@@ -322,10 +322,19 @@
                     Background="{DynamicResource ToolbarBackground}"
                     BorderBrush="{DynamicResource ToolbarBorderBrush}" BorderThickness="0,0,0,1"
                     Visibility="Collapsed">
-                <StackPanel x:Name="ToolbarPanel" Orientation="Horizontal"
-                            Margin="4">
+                <DockPanel x:Name="ToolbarOuterPanel" LastChildFill="True">
+                    <!-- Meta tab strip (groups). Hidden until 2+ groups exist. -->
+                    <Border x:Name="MetaTabBorder" DockPanel.Dock="Top"
+                            BorderBrush="{DynamicResource ToolbarBorderBrush}"
+                            BorderThickness="0,0,0,1"
+                            Visibility="Collapsed">
+                        <StackPanel x:Name="MetaTabPanel" Orientation="Horizontal">
+                            <!-- Meta tab elements are inserted here dynamically -->
+                        </StackPanel>
+                    </Border>
                     <!-- Project tab buttons are inserted here dynamically -->
-                </StackPanel>
+                    <StackPanel x:Name="ToolbarPanel" Orientation="Horizontal" />
+                </DockPanel>
             </Border>
 
             <!-- Main Content Area -->

--- a/src/AgentDock/MainWindow.xaml
+++ b/src/AgentDock/MainWindow.xaml
@@ -102,58 +102,15 @@
                         </MenuItem>
                     </MenuItem>
                     <MenuItem Header="S_ettings">
-                        <MenuItem Header="_Theme" x:Name="ThemeMenu">
+                        <MenuItem Header="_Workspace Settings..." Click="WorkspaceSettings_Click">
                             <MenuItem.Icon>
-                                <TextBlock Text="&#xE790;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                <TextBlock Text="&#xE821;" FontFamily="Segoe MDL2 Assets" FontSize="12"
                                            Foreground="{DynamicResource MenuIconForeground}" />
                             </MenuItem.Icon>
-                            <!-- Items populated dynamically in code-behind -->
                         </MenuItem>
-                        <MenuItem Header="Toolbar _Position">
-                            <MenuItem.Icon>
-                                <TextBlock Text="&#xE8E4;" FontFamily="Segoe MDL2 Assets" FontSize="12"
-                                           Foreground="{DynamicResource MenuIconForeground}" />
-                            </MenuItem.Icon>
-                            <MenuItem Header="_Top" x:Name="ToolbarTopMenu" IsCheckable="True" IsChecked="True"
-                                      Click="ToolbarPosition_Click" Tag="Top">
-                                <MenuItem.Icon>
-                                    <TextBlock Text="&#xE74A;" FontFamily="Segoe MDL2 Assets" FontSize="12"
-                                               Foreground="{DynamicResource MenuIconForeground}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Header="_Left" x:Name="ToolbarLeftMenu" IsCheckable="True"
-                                      Click="ToolbarPosition_Click" Tag="Left">
-                                <MenuItem.Icon>
-                                    <TextBlock Text="&#xE76B;" FontFamily="Segoe MDL2 Assets" FontSize="12"
-                                               Foreground="{DynamicResource MenuIconForeground}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Header="_Right" x:Name="ToolbarRightMenu" IsCheckable="True"
-                                      Click="ToolbarPosition_Click" Tag="Right">
-                                <MenuItem.Icon>
-                                    <TextBlock Text="&#xE76C;" FontFamily="Segoe MDL2 Assets" FontSize="12"
-                                               Foreground="{DynamicResource MenuIconForeground}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Header="_Bottom" x:Name="ToolbarBottomMenu" IsCheckable="True"
-                                      Click="ToolbarPosition_Click" Tag="Bottom">
-                                <MenuItem.Icon>
-                                    <TextBlock Text="&#xE74B;" FontFamily="Segoe MDL2 Assets" FontSize="12"
-                                               Foreground="{DynamicResource MenuIconForeground}" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                        </MenuItem>
-                        <Separator />
-                        <MenuItem Header="_Claude Path Override..." Click="ClaudePathOverride_Click">
+                        <MenuItem Header="_App Settings..." Click="AppSettings_Click">
                             <MenuItem.Icon>
                                 <TextBlock Text="&#xE713;" FontFamily="Segoe MDL2 Assets" FontSize="12"
-                                           Foreground="{DynamicResource MenuIconForeground}" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <Separator />
-                        <MenuItem Header="Open _Logs Folder" Click="OpenLogsFolder_Click">
-                            <MenuItem.Icon>
-                                <TextBlock Text="&#xE838;" FontFamily="Segoe MDL2 Assets" FontSize="12"
                                            Foreground="{DynamicResource MenuIconForeground}" />
                             </MenuItem.Icon>
                         </MenuItem>

--- a/src/AgentDock/MainWindow.xaml
+++ b/src/AgentDock/MainWindow.xaml
@@ -48,8 +48,8 @@
                        Margin="10,0,6,0"
                        WindowChrome.IsHitTestVisibleInChrome="True" />
 
-                <!-- Product name -->
-                <TextBlock Grid.Column="1"
+                <!-- Product name + version -->
+                <TextBlock x:Name="ProductNameText" Grid.Column="1"
                            Text="Agent Dock"
                            FontSize="12"
                            FontWeight="SemiBold"

--- a/src/AgentDock/MainWindow.xaml.cs
+++ b/src/AgentDock/MainWindow.xaml.cs
@@ -79,6 +79,8 @@ public partial class MainWindow : Window
         Log.Info("MainWindow constructor starting");
         InitializeComponent();
 
+        ProductNameText.Text = $"Agent Dock v{App.Version}";
+
         _toolbarPositionMenuItems = [ToolbarTopMenu, ToolbarLeftMenu, ToolbarRightMenu, ToolbarBottomMenu];
 
         // Create the + button for the project tab bar
@@ -136,6 +138,7 @@ public partial class MainWindow : Window
         Loaded += async (_, _) =>
         {
             await RunStartupPrerequisiteChecks();
+            ShowWhatsNewIfNewVersion();
             await CheckForAppUpdateAsync();
         };
 
@@ -629,6 +632,50 @@ public partial class MainWindow : Window
 
         UpdateTitleBar(); // restore normal title
         Log.Info("Startup prerequisite check: complete");
+    }
+
+    private const string LastWhatsNewVersionKey = "LastWhatsNewVersionShown";
+
+    /// <summary>
+    /// If the app version has changed since the last time we showed the "What's New" popup,
+    /// show release notes for the new version. On first install (no prior key), records the
+    /// current version silently without showing the popup.
+    /// </summary>
+    private void ShowWhatsNewIfNewVersion()
+    {
+        try
+        {
+            var currentVersion = App.Version;
+            var lastShown = AppSettings.GetString(LastWhatsNewVersionKey, "");
+
+            if (string.IsNullOrEmpty(lastShown))
+            {
+                Log.Info($"WhatsNew: first install, recording v{currentVersion} silently");
+                AppSettings.SetString(LastWhatsNewVersionKey, currentVersion);
+                return;
+            }
+
+            if (lastShown == currentVersion)
+                return;
+
+            var notes = ReleaseNotesService.GetNotesForVersion(currentVersion);
+            if (string.IsNullOrWhiteSpace(notes))
+            {
+                Log.Info($"WhatsNew: no embedded notes for v{currentVersion}, skipping popup");
+                AppSettings.SetString(LastWhatsNewVersionKey, currentVersion);
+                return;
+            }
+
+            Log.Info($"WhatsNew: showing release notes for v{currentVersion} (was v{lastShown})");
+            var window = new WhatsNewWindow(this, currentVersion, notes);
+            window.ShowDialog();
+
+            AppSettings.SetString(LastWhatsNewVersionKey, currentVersion);
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"WhatsNew: failed to show popup — {ex.Message}");
+        }
     }
 
     private async System.Threading.Tasks.Task CheckForAppUpdateAsync()

--- a/src/AgentDock/MainWindow.xaml.cs
+++ b/src/AgentDock/MainWindow.xaml.cs
@@ -45,6 +45,10 @@ public partial class MainWindow : Window
     private readonly Dictionary<ProjectInfo, TodoListControl> _projectTodoListControls = [];
     private ProjectInfo? _activeProject;
 
+    // Tab grouping state (meta tabs)
+    private readonly List<ProjectGroup> _groups = [];
+    private string? _activeGroupId;
+
     // Workspace state
     private string? _currentWorkspacePath;
     private bool _workspaceDirty;
@@ -89,6 +93,10 @@ public partial class MainWindow : Window
         ToolbarPanel.DragOver += ToolbarPanel_DragOver;
         ToolbarPanel.Drop += ToolbarPanel_Drop;
         ToolbarPanel.DragLeave += (_, _) => RemoveTabDragIndicator();
+
+        // MetaTabPanel is the drop target for moving a project tab into a different group.
+        // Each meta tab element also accepts drop individually (set on creation).
+        MetaTabPanel.AllowDrop = true;
 
         CommandBindings.Add(new CommandBinding(AddProjectCommand, (_, _) => AddProject()));
         CommandBindings.Add(new CommandBinding(SaveWorkspaceCommand, (_, _) => SaveWorkspace()));
@@ -751,6 +759,11 @@ public partial class MainWindow : Window
 
         var project = new ProjectInfo { FolderPath = folderPath };
         project.CustomName = ProjectSettingsManager.Load(folderPath).Name;
+
+        // If groups are active, the new project joins whichever group is currently visible
+        if (_groups.Count > 0 && _activeGroupId != null)
+            project.GroupId = _activeGroupId;
+
         _projects.Add(project);
         Log.Info($"AddProjectFromPath: created ProjectInfo for '{project.FolderName}'");
 
@@ -963,13 +976,13 @@ public partial class MainWindow : Window
 
         _projectTabIcons[project] = statusGrid;
 
-        // Custom template: border only, no default button chrome
+        // VS Code-like tab: flat rectangle, transparent bottom-accent on inactive,
+        // themed bottom-accent on active. No corner radius, no top/left/right borders.
         var tabTemplate = new ControlTemplate(typeof(Button));
         var borderFactory = new FrameworkElementFactory(typeof(Border), "Bd");
         borderFactory.SetValue(Border.BackgroundProperty, new TemplateBindingExtension(BackgroundProperty));
         borderFactory.SetValue(Border.BorderBrushProperty, new TemplateBindingExtension(BorderBrushProperty));
         borderFactory.SetValue(Border.BorderThicknessProperty, new TemplateBindingExtension(BorderThicknessProperty));
-        borderFactory.SetValue(Border.CornerRadiusProperty, new CornerRadius(3));
         borderFactory.SetValue(Border.PaddingProperty, new TemplateBindingExtension(PaddingProperty));
         var contentPresenter = new FrameworkElementFactory(typeof(ContentPresenter));
         contentPresenter.SetValue(ContentPresenter.VerticalAlignmentProperty, VerticalAlignment.Center);
@@ -979,12 +992,12 @@ public partial class MainWindow : Window
         var button = new Button
         {
             MinWidth = 44,
-            Height = 36,
-            Margin = new Thickness(2),
-            Padding = new Thickness(8, 4, 8, 4),
-            Background = Brushes.Transparent,
-            BorderBrush = ThemeManager.GetBrush("TabButtonBorderBrush"),
-            BorderThickness = new Thickness(1),
+            Height = 32,
+            Margin = new Thickness(0),
+            Padding = new Thickness(12, 0, 12, 0),
+            Background = ThemeManager.GetBrush("TabButtonInactiveBackground"),
+            BorderBrush = Brushes.Transparent,
+            BorderThickness = new Thickness(0, 0, 0, 2),
             Cursor = Cursors.Hand,
             HorizontalContentAlignment = HorizontalAlignment.Left,
             Tag = project,
@@ -1014,18 +1027,15 @@ public partial class MainWindow : Window
                 SwitchToProject(project);
         };
 
-        // Hover: highlight border only (no background fill)
         button.MouseEnter += (_, _) =>
         {
             if (project != _activeProject)
-                button.BorderBrush = ThemeManager.GetBrush("TabButtonHoverBorderBrush");
+                button.Background = MakeTabHoverBrush();
         };
         button.MouseLeave += (_, _) =>
         {
             if (project != _activeProject)
-                button.BorderBrush = ThemeManager.GetBrush("TabButtonBorderBrush");
-            else
-                button.BorderBrush = ThemeManager.GetBrush("TabButtonActiveBorderBrush");
+                button.Background = ThemeManager.GetBrush("TabButtonInactiveBackground");
         };
 
         // Drag initiation (DragOver/Drop handled at ToolbarPanel level)
@@ -1057,6 +1067,8 @@ public partial class MainWindow : Window
         {
             Items =
             {
+                CreateMenuItem("Add to new group", () => AddProjectToNewGroup(project)),
+                new Separator(),
                 CreateMenuItem("Close Project", () => CloseProject(project)),
                 CreateMenuItem("Open in Explorer", () => OpenInExplorer(project))
             }
@@ -1083,9 +1095,9 @@ public partial class MainWindow : Window
 
         var button = new Button
         {
-            Width = 36,
-            Height = 36,
-            Margin = new Thickness(2),
+            Width = 32,
+            Height = 32,
+            Margin = new Thickness(6, 0, 0, 0),
             Background = Brushes.Transparent,
             BorderBrush = ThemeManager.GetBrush("AddButtonBorderBrush"),
             BorderThickness = new Thickness(1),
@@ -1122,16 +1134,20 @@ public partial class MainWindow : Window
     /// <summary>
     /// Finds the insertion index among tab buttons for the given mouse position.
     /// Returns the index in _projects where the dragged tab should be inserted.
+    /// Hidden (group-filtered) tabs are skipped so reordering operates only on what's visible.
     /// </summary>
     private int GetTabInsertionIndex(DragEventArgs e)
     {
         var isHorizontal = ToolbarPanel.Orientation == Orientation.Horizontal;
+        ProjectInfo? lastVisibleBefore = null;
 
         for (int i = 0; i < ToolbarPanel.Children.Count; i++)
         {
             if (ToolbarPanel.Children[i] is not FrameworkElement child)
                 continue;
-            if (child == _toolbarAddButton || child == _tabDragIndicator || child.Tag is not ProjectInfo)
+            if (child == _toolbarAddButton || child == _tabDragIndicator || child.Tag is not ProjectInfo proj)
+                continue;
+            if (child.Visibility != Visibility.Visible)
                 continue;
 
             var pos = e.GetPosition(child);
@@ -1139,15 +1155,16 @@ public partial class MainWindow : Window
             var coord = isHorizontal ? pos.X : pos.Y;
 
             if (coord < midpoint)
-            {
-                // Before this tab — find its project index
-                var proj = (ProjectInfo)child.Tag;
                 return _projects.IndexOf(proj);
-            }
+
+            lastVisibleBefore = proj;
         }
 
-        // After all tabs
-        return _projects.Count;
+        // After all visible tabs — insert immediately after the last one so hidden tabs
+        // keep their relative position in the underlying list.
+        return lastVisibleBefore != null
+            ? _projects.IndexOf(lastVisibleBefore) + 1
+            : _projects.Count;
     }
 
     private void ToolbarPanel_DragOver(object sender, DragEventArgs e)
@@ -1253,6 +1270,383 @@ public partial class MainWindow : Window
         var item = new MenuItem { Header = header };
         item.Click += (_, _) => action();
         return item;
+    }
+
+    // --- Tab groups (meta tabs) ---
+
+    /// <summary>
+    /// Right-click "Add to new group" action. On first use, splits all existing tabs
+    /// into an implicit "Ungrouped" group plus a new group containing the right-clicked tab.
+    /// On subsequent uses, just creates the next numbered group.
+    /// </summary>
+    private void AddProjectToNewGroup(ProjectInfo project)
+    {
+        // First-time: also create the "Ungrouped" bucket for everything else
+        if (_groups.Count == 0)
+        {
+            var ungrouped = new ProjectGroup
+            {
+                Id = Guid.NewGuid().ToString(),
+                Name = "Ungrouped",
+                Order = 0
+            };
+            _groups.Add(ungrouped);
+            foreach (var p in _projects)
+                p.GroupId = ungrouped.Id;
+        }
+
+        // Create the new group with an auto-name
+        var newGroup = new ProjectGroup
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = NextGroupName(),
+            Order = _groups.Count == 0 ? 1 : _groups.Max(g => g.Order) + 1
+        };
+        _groups.Add(newGroup);
+        project.GroupId = newGroup.Id;
+
+        _activeGroupId = newGroup.Id;
+        RefreshMetaTabBar();
+        RefreshProjectTabVisibility();
+
+        // Ensure the active project is one that's visible in the new group
+        if (_activeProject != project)
+            SwitchToProject(project);
+
+        SetWorkspaceDirty();
+    }
+
+    private string NextGroupName()
+    {
+        // Find the smallest unused "Group N"
+        var existing = new HashSet<string>(_groups.Select(g => g.Name), StringComparer.OrdinalIgnoreCase);
+        for (int n = 1; n < 1000; n++)
+        {
+            var candidate = $"Group {n}";
+            if (!existing.Contains(candidate))
+                return candidate;
+        }
+        return "Group";
+    }
+
+    /// <summary>
+    /// Rebuilds <see cref="MetaTabPanel"/> from <see cref="_groups"/>.
+    /// Hides the meta bar when fewer than two groups exist.
+    /// </summary>
+    private void RefreshMetaTabBar()
+    {
+        MetaTabPanel.Children.Clear();
+
+        if (_groups.Count < 2)
+        {
+            MetaTabBorder.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        MetaTabBorder.Visibility = Visibility.Visible;
+
+        foreach (var group in _groups.OrderBy(g => g.Order))
+            MetaTabPanel.Children.Add(CreateMetaTabElement(group));
+    }
+
+    /// <summary>
+    /// Hides project tabs that aren't in the active group when grouping is in use.
+    /// Shows every tab otherwise.
+    /// </summary>
+    private void RefreshProjectTabVisibility()
+    {
+        var filtering = _groups.Count >= 2 && _activeGroupId != null;
+
+        foreach (var (project, button) in _projectTabButtons)
+        {
+            button.Visibility = !filtering || project.GroupId == _activeGroupId
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        }
+    }
+
+    private Button CreateMetaTabElement(ProjectGroup group)
+    {
+        // Flat template (matches project tab visual language)
+        var template = new ControlTemplate(typeof(Button));
+        var borderFactory = new FrameworkElementFactory(typeof(Border), "Bd");
+        borderFactory.SetValue(Border.BackgroundProperty, new TemplateBindingExtension(BackgroundProperty));
+        borderFactory.SetValue(Border.BorderBrushProperty, new TemplateBindingExtension(BorderBrushProperty));
+        borderFactory.SetValue(Border.BorderThicknessProperty, new TemplateBindingExtension(BorderThicknessProperty));
+        borderFactory.SetValue(Border.PaddingProperty, new TemplateBindingExtension(PaddingProperty));
+        var contentPresenter = new FrameworkElementFactory(typeof(ContentPresenter));
+        contentPresenter.SetValue(ContentPresenter.VerticalAlignmentProperty, VerticalAlignment.Center);
+        borderFactory.AppendChild(contentPresenter);
+        template.VisualTree = borderFactory;
+
+        var label = new TextBlock
+        {
+            Text = group.Name,
+            FontSize = 11,
+            VerticalAlignment = VerticalAlignment.Center,
+            Foreground = ThemeManager.GetBrush("TabButtonForeground"),
+        };
+
+        var isActive = group.Id == _activeGroupId;
+
+        var button = new Button
+        {
+            Tag = group,
+            MinWidth = 32,
+            Height = 22,
+            Margin = new Thickness(0),
+            Padding = new Thickness(10, 0, 10, 0),
+            Background = isActive
+                ? ThemeManager.GetBrush("TabButtonActiveBackground")
+                : ThemeManager.GetBrush("TabButtonInactiveBackground"),
+            BorderBrush = isActive
+                ? ThemeManager.GetBrush("TabButtonActiveBorderBrush")
+                : Brushes.Transparent,
+            BorderThickness = new Thickness(0, 0, 0, 2),
+            Cursor = Cursors.Hand,
+            Template = template,
+            Content = label,
+            AllowDrop = true,
+            ToolTip = "Click to switch group · click again to rename · right-click for options"
+        };
+
+        button.Click += (_, _) =>
+        {
+            // Ignore the click that bubbles from inside the rename TextBox
+            if (button.Content is TextBox)
+                return;
+            if (group.Id == _activeGroupId)
+                StartMetaTabRename(group, button, label);
+            else
+                SetActiveGroup(group.Id);
+        };
+
+        button.MouseEnter += (_, _) =>
+        {
+            if (group.Id != _activeGroupId && button.Content is TextBlock)
+                button.Background = MakeTabHoverBrush();
+        };
+        button.MouseLeave += (_, _) =>
+        {
+            if (group.Id != _activeGroupId && button.Content is TextBlock)
+                button.Background = ThemeManager.GetBrush("TabButtonInactiveBackground");
+        };
+
+        // Right-click context menu (Delete group, only if empty)
+        var deleteItem = CreateMenuItem("Delete group", () => DeleteGroup(group.Id));
+        button.ContextMenu = new ContextMenu { Items = { deleteItem } };
+        button.ContextMenuOpening += (_, _) =>
+        {
+            deleteItem.IsEnabled = !_projects.Any(p => p.GroupId == group.Id);
+        };
+
+        // Drag-drop target: dropping a project tab here moves it to this group
+        button.DragOver += (_, e) =>
+        {
+            if (e.Data.GetDataPresent("ProjectTab"))
+            {
+                e.Effects = DragDropEffects.Move;
+                button.Background = MakeTabHoverBrush();
+                e.Handled = true;
+            }
+            else
+            {
+                e.Effects = DragDropEffects.None;
+            }
+        };
+        button.DragLeave += (_, _) =>
+        {
+            if (group.Id == _activeGroupId)
+                button.Background = ThemeManager.GetBrush("TabButtonActiveBackground");
+            else
+                button.Background = ThemeManager.GetBrush("TabButtonInactiveBackground");
+        };
+        button.Drop += (_, e) =>
+        {
+            // Reset hover-tinted background regardless of outcome
+            button.Background = group.Id == _activeGroupId
+                ? ThemeManager.GetBrush("TabButtonActiveBackground")
+                : ThemeManager.GetBrush("TabButtonInactiveBackground");
+
+            if (e.Data.GetData("ProjectTab") is ProjectInfo dropped)
+            {
+                MoveProjectToGroup(dropped, group.Id);
+                e.Handled = true;
+            }
+        };
+
+        return button;
+    }
+
+    private void StartMetaTabRename(ProjectGroup group, Button button, TextBlock label)
+    {
+        var textbox = new TextBox
+        {
+            Text = group.Name,
+            FontSize = 11,
+            MinWidth = Math.Max(60, label.ActualWidth + 16),
+            VerticalAlignment = VerticalAlignment.Center,
+            VerticalContentAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(-4, 0, -4, 0),
+            Padding = new Thickness(2, 0, 2, 0),
+            Background = ThemeManager.GetBrush("ContentBackground"),
+            Foreground = ThemeManager.GetBrush("TabButtonForeground"),
+            BorderThickness = new Thickness(1),
+            BorderBrush = ThemeManager.GetBrush("TabButtonActiveBorderBrush")
+        };
+
+        var committed = false;
+        void Commit(bool save)
+        {
+            if (committed) return;
+            committed = true;
+            if (save && !string.IsNullOrWhiteSpace(textbox.Text))
+            {
+                var newName = textbox.Text.Trim();
+                if (!string.Equals(newName, group.Name, StringComparison.Ordinal))
+                {
+                    group.Name = newName;
+                    SetWorkspaceDirty();
+                }
+            }
+            label.Text = group.Name;
+            button.Content = label;
+        }
+
+        textbox.LostFocus += (_, _) => Commit(true);
+        textbox.KeyDown += (_, e) =>
+        {
+            if (e.Key == Key.Enter) { Commit(true); e.Handled = true; }
+            else if (e.Key == Key.Escape) { Commit(false); e.Handled = true; }
+        };
+
+        button.Content = textbox;
+
+        // Defer focus until after the visual tree has placed the textbox
+        Dispatcher.BeginInvoke(() =>
+        {
+            textbox.Focus();
+            Keyboard.Focus(textbox);
+            textbox.SelectAll();
+        }, DispatcherPriority.Input);
+    }
+
+    private void SetActiveGroup(string groupId)
+    {
+        if (_activeGroupId == groupId)
+            return;
+
+        _activeGroupId = groupId;
+        RefreshMetaTabBar();
+        RefreshProjectTabVisibility();
+
+        // If the active project isn't in the new group, switch to one that is
+        if (_activeProject == null || _activeProject.GroupId != groupId)
+        {
+            var firstInGroup = _projects.FirstOrDefault(p => p.GroupId == groupId);
+            if (firstInGroup != null)
+                SwitchToProject(firstInGroup);
+            else
+            {
+                // Empty group — show empty state but keep workspace open
+                _activeProject = null;
+                ProjectContentHost.Content = null;
+                ProjectContentHost.Visibility = Visibility.Collapsed;
+                EmptyStatePanel.Visibility = Visibility.Visible;
+                UpdateTitleBar();
+            }
+        }
+        // Pure group navigation — like project switching, doesn't dirty the workspace
+    }
+
+    private void MoveProjectToGroup(ProjectInfo project, string groupId)
+    {
+        if (project.GroupId == groupId)
+            return;
+        if (_groups.All(g => g.Id != groupId))
+            return;
+
+        project.GroupId = groupId;
+        RefreshProjectTabVisibility();
+
+        // If we just moved the active project out of the active group, show the next visible one.
+        // When the source group is now empty, follow the project to its new group so the user
+        // isn't left staring at an empty meta tab.
+        if (project == _activeProject && groupId != _activeGroupId)
+        {
+            var next = _projects.FirstOrDefault(p => p.GroupId == _activeGroupId);
+            if (next != null)
+            {
+                SwitchToProject(next);
+            }
+            else
+            {
+                _activeGroupId = groupId;
+                RefreshMetaTabBar();
+                RefreshProjectTabVisibility();
+            }
+        }
+
+        SetWorkspaceDirty();
+    }
+
+    private void DeleteGroup(string groupId)
+    {
+        var group = _groups.FirstOrDefault(g => g.Id == groupId);
+        if (group == null) return;
+        if (_projects.Any(p => p.GroupId == groupId))
+            return; // Only empty groups can be deleted
+
+        _groups.Remove(group);
+
+        // If only one group remains, dissolve all grouping (back to pristine no-group state)
+        if (_groups.Count <= 1)
+        {
+            _groups.Clear();
+            _activeGroupId = null;
+            foreach (var p in _projects)
+                p.GroupId = null;
+        }
+        else if (_activeGroupId == groupId)
+        {
+            _activeGroupId = _groups.OrderBy(g => g.Order).First().Id;
+        }
+
+        RefreshMetaTabBar();
+        RefreshProjectTabVisibility();
+
+        // Ensure something is showing in the content area
+        if (_activeGroupId != null &&
+            (_activeProject == null || _activeProject.GroupId != _activeGroupId))
+        {
+            var next = _projects.FirstOrDefault(p => p.GroupId == _activeGroupId);
+            if (next != null) SwitchToProject(next);
+        }
+
+        SetWorkspaceDirty();
+    }
+
+    /// <summary>
+    /// Returns the orientation for the meta tab strip and adjusts the meta border thickness
+    /// for the supplied toolbar position.
+    /// </summary>
+    private void ApplyMetaTabLayoutForToolbarPosition(string position)
+    {
+        switch (position)
+        {
+            case "Top":
+            case "Bottom":
+                DockPanel.SetDock(MetaTabBorder, Dock.Top);
+                MetaTabBorder.BorderThickness = new Thickness(0, 0, 0, 1);
+                MetaTabPanel.Orientation = Orientation.Horizontal;
+                break;
+            case "Left":
+            case "Right":
+                DockPanel.SetDock(MetaTabBorder, Dock.Top);
+                MetaTabBorder.BorderThickness = new Thickness(0, 0, 0, 1);
+                MetaTabPanel.Orientation = Orientation.Horizontal;
+                break;
+        }
     }
 
     private (DockingManager, AiChatControl, GitStatusControl, ProjectDescriptionControl, TodoListControl) CreateProjectDockingLayout(ProjectInfo project, string? layoutXml = null)
@@ -1676,6 +2070,15 @@ public partial class MainWindow : Window
         if (_activeProject == project)
             return;
 
+        // If groups are in use and this project lives in a different group,
+        // switch the active group so its tab is actually visible.
+        if (_groups.Count >= 2 && project.GroupId != null && project.GroupId != _activeGroupId)
+        {
+            _activeGroupId = project.GroupId;
+            RefreshMetaTabBar();
+            RefreshProjectTabVisibility();
+        }
+
         // Update tab button styles
         if (_activeProject != null && _projectTabButtons.TryGetValue(_activeProject, out var prevButton))
             SetTabButtonActive(prevButton, false);
@@ -1816,8 +2219,19 @@ public partial class MainWindow : Window
         else
         {
             button.Background = ThemeManager.GetBrush("TabButtonInactiveBackground");
-            button.BorderBrush = ThemeManager.GetBrush("TabButtonBorderBrush");
+            button.BorderBrush = Brushes.Transparent;
         }
+    }
+
+    /// <summary>
+    /// Subtle hover background for inactive tabs, derived from the active background
+    /// so it matches every theme without requiring per-theme brush additions.
+    /// </summary>
+    private static SolidColorBrush MakeTabHoverBrush()
+    {
+        var activeBrush = ThemeManager.GetBrush("TabButtonActiveBackground");
+        var c = activeBrush.Color;
+        return new SolidColorBrush(Color.FromArgb(96, c.R, c.G, c.B));
     }
 
     private void CloseActiveProject()
@@ -1869,14 +2283,28 @@ public partial class MainWindow : Window
 
         SetWorkspaceDirty();
 
-        // If this was the active project, switch to another or show empty state
+        // If this was the active project, switch to another or show empty state.
+        // When groups are active, prefer a project in the same active group.
         if (_activeProject == project)
         {
             _activeProject = null;
 
-            if (_projects.Count > 0)
+            var filtering = _groups.Count >= 2 && _activeGroupId != null;
+            ProjectInfo? next = filtering
+                ? _projects.LastOrDefault(p => p.GroupId == _activeGroupId)
+                : _projects.LastOrDefault();
+
+            if (next != null)
             {
-                SwitchToProject(_projects[^1]);
+                SwitchToProject(next);
+            }
+            else if (_projects.Count > 0)
+            {
+                // Active group is empty but other projects exist — leave empty content
+                ProjectContentHost.Content = null;
+                ProjectContentHost.Visibility = Visibility.Collapsed;
+                EmptyStatePanel.Visibility = Visibility.Visible;
+                UpdateTitleBar();
             }
             else
             {
@@ -1928,6 +2356,10 @@ public partial class MainWindow : Window
 
         _projects.Clear();
         _activeProject = null;
+        _groups.Clear();
+        _activeGroupId = null;
+        MetaTabPanel.Children.Clear();
+        MetaTabBorder.Visibility = Visibility.Collapsed;
         ProjectContentHost.Content = null;
         ProjectContentHost.Visibility = Visibility.Collapsed;
         EmptyStatePanel.Visibility = Visibility.Visible;
@@ -2122,14 +2554,22 @@ public partial class MainWindow : Window
         {
             Theme = ThemeManager.CurrentTheme.Id,
             ToolbarPosition = _currentToolbarPosition,
-            ActiveProjectPath = _activeProject?.FolderPath
+            ActiveProjectPath = _activeProject?.FolderPath,
+            ActiveGroupId = _activeGroupId,
+            Groups = _groups.Select(g => new ProjectGroup
+            {
+                Id = g.Id,
+                Name = g.Name,
+                Order = g.Order
+            }).ToList()
         };
 
         foreach (var project in _projects)
         {
             var wp = new WorkspaceProject
             {
-                FolderPath = project.FolderPath
+                FolderPath = project.FolderPath,
+                GroupId = project.GroupId
             };
 
             // Serialize AvalonDock layout
@@ -2219,18 +2659,58 @@ public partial class MainWindow : Window
             AppSettings.SetString("ToolbarPosition", workspace.ToolbarPosition);
         }
 
-        // Restore projects
+        // Restore groups before adding projects so AddProjectFromPath doesn't auto-assign GroupId
+        _groups.Clear();
+        _activeGroupId = null;
+        if (workspace.Groups != null && workspace.Groups.Count > 0)
+        {
+            foreach (var g in workspace.Groups)
+                _groups.Add(new ProjectGroup { Id = g.Id, Name = g.Name, Order = g.Order });
+        }
+
+        // Restore projects (group assignment is applied below from the workspace file)
         ProjectInfo? activeProject = null;
+        var pathToGroup = workspace.Projects.ToDictionary(
+            p => p.FolderPath,
+            p => p.GroupId,
+            StringComparer.OrdinalIgnoreCase);
+
         foreach (var wp in workspace.Projects)
         {
             var project = AddProjectFromPath(wp.FolderPath, wp.DockingLayout);
-            if (project != null && string.Equals(wp.FolderPath, workspace.ActiveProjectPath, StringComparison.OrdinalIgnoreCase))
-                activeProject = project;
+            if (project != null)
+            {
+                // Overwrite any default group assignment with the serialized one
+                project.GroupId = pathToGroup.TryGetValue(wp.FolderPath, out var gid) ? gid : null;
+                if (string.Equals(wp.FolderPath, workspace.ActiveProjectPath, StringComparison.OrdinalIgnoreCase))
+                    activeProject = project;
+            }
         }
 
-        // Switch to the active project
+        // Determine active group (prefer saved, fall back to first group, or null if none)
+        _activeGroupId = workspace.ActiveGroupId != null && _groups.Any(g => g.Id == workspace.ActiveGroupId)
+            ? workspace.ActiveGroupId
+            : _groups.OrderBy(g => g.Order).FirstOrDefault()?.Id;
+
+        RefreshMetaTabBar();
+        RefreshProjectTabVisibility();
+
+        // Switch to the active project (if it's hidden by group filter, switch to its group)
         if (activeProject != null)
+        {
+            if (_groups.Count >= 2 && activeProject.GroupId != null && activeProject.GroupId != _activeGroupId)
+                _activeGroupId = activeProject.GroupId;
+            RefreshMetaTabBar();
+            RefreshProjectTabVisibility();
             SwitchToProject(activeProject);
+        }
+        else if (_activeGroupId != null)
+        {
+            // Active project missing — pick the first project in the active group
+            var first = _projects.FirstOrDefault(p => p.GroupId == _activeGroupId);
+            if (first != null)
+                SwitchToProject(first);
+        }
 
         _suppressDirty = false;
         _currentWorkspacePath = filePath;
@@ -2404,6 +2884,7 @@ public partial class MainWindow : Window
         DockPanel.SetDock(ToolbarBorder, dock);
         ToolbarBorder.BorderThickness = borderThickness;
         ToolbarPanel.Orientation = orientation;
+        ApplyMetaTabLayoutForToolbarPosition(position);
         _currentToolbarPosition = position;
 
         // Force DockPanel layout recalculation
@@ -2507,6 +2988,9 @@ public partial class MainWindow : Window
 
         // Update toolbar + button accent
         _toolbarAddButton.BorderBrush = ThemeManager.GetBrush("AddButtonBorderBrush");
+
+        // Rebuild meta tab strip so its colors pick up the new theme
+        RefreshMetaTabBar();
 
         // Update taskbar icon with new theme accent bar
         UpdateTaskbarIcon();

--- a/src/AgentDock/MainWindow.xaml.cs
+++ b/src/AgentDock/MainWindow.xaml.cs
@@ -1347,7 +1347,18 @@ public partial class MainWindow : Window
         gitStatusControl.DiffRequested += (filePath, diffContent) =>
         {
             Log.Info($"DiffRequested: {filePath}");
-            filePreviewControl.ShowDiff(diffContent);
+            var absolutePath = Path.IsPathRooted(filePath)
+                ? filePath
+                : Path.Combine(project.FolderPath, filePath);
+            filePreviewControl.ShowDiff(absolutePath, diffContent);
+        };
+
+        // From the diff preview, reveal the underlying file in the explorer; the
+        // existing FileSelected wiring then swaps the preview from diff to full file.
+        filePreviewControl.RevealInExplorerRequested += path =>
+        {
+            Log.Info($"RevealInExplorerRequested: {path}");
+            fileExplorerControl.RevealAndSelect(path);
         };
 
         // Refresh file explorer when file system changes (reuses git status watcher)

--- a/src/AgentDock/MainWindow.xaml.cs
+++ b/src/AgentDock/MainWindow.xaml.cs
@@ -30,7 +30,6 @@ public partial class MainWindow : Window
     public static readonly RoutedUICommand CloseProjectCommand =
         new("Close Project", nameof(CloseProjectCommand), typeof(MainWindow));
 
-    private readonly MenuItem[] _toolbarPositionMenuItems;
     private string _currentToolbarPosition = "Top";
 
     private readonly List<ProjectInfo> _projects = [];
@@ -81,8 +80,6 @@ public partial class MainWindow : Window
 
         ProductNameText.Text = $"Agent Dock v{App.Version}";
 
-        _toolbarPositionMenuItems = [ToolbarTopMenu, ToolbarLeftMenu, ToolbarRightMenu, ToolbarBottomMenu];
-
         // Create the + button for the project tab bar
         _toolbarAddButton = CreateToolbarAddButton();
         ToolbarPanel.Children.Add(_toolbarAddButton);
@@ -97,8 +94,7 @@ public partial class MainWindow : Window
         CommandBindings.Add(new CommandBinding(SaveWorkspaceCommand, (_, _) => SaveWorkspace()));
         CommandBindings.Add(new CommandBinding(CloseProjectCommand, (_, _) => CloseActiveProject()));
 
-        // Build theme menu and subscribe to changes
-        PopulateThemeMenu();
+        // Subscribe to theme changes
         ThemeManager.ThemeChanged += OnThemeChanged;
         UpdateTaskbarIcon();
 
@@ -291,78 +287,53 @@ public partial class MainWindow : Window
 
     // --- Settings Menu ---
 
-    private void ThemeMenuItem_Click(object sender, RoutedEventArgs e)
+    private void WorkspaceSettings_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is MenuItem { Tag: string themeId })
-            ThemeManager.ApplyTheme(themeId);
-    }
-
-    private void ToolbarPosition_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not MenuItem clicked || clicked.Tag is not string position)
-            return;
-
-        SetToolbarPosition(position);
-        AppSettings.SetString("ToolbarPosition", position);
-    }
-
-    private void ClaudePathOverride_Click(object sender, RoutedEventArgs e)
-    {
-        var currentPath = ClaudeSession.ClaudeBinaryPath;
-        var result = ThemedMessageBox.Show(
+        var result = Windows.WorkspaceSettingsDialog.Show(
             this,
-            $"Current Claude path: {currentPath}\n\n" +
-            "Do you want to select a custom Claude binary?\n" +
-            "Click Yes to browse, No to reset to default (\"claude\" from PATH).",
-            "Claude Path Override",
-            MessageBoxButton.YesNoCancel,
-            MessageBoxImage.Question);
+            ThemeManager.CurrentTheme.Id,
+            _currentToolbarPosition);
 
-        if (result == MessageBoxResult.Cancel)
-            return;
+        if (result == null) return;
 
-        if (result == MessageBoxResult.No)
+        if (result.ThemeId != ThemeManager.CurrentTheme.Id)
+            ThemeManager.ApplyTheme(result.ThemeId);
+
+        if (result.ToolbarPosition != _currentToolbarPosition)
         {
-            ClaudeSession.ClaudeBinaryPath = "claude";
-            AppSettings.SetString("ClaudePath", "");
-            Log.Info("ClaudePathOverride: reset to default");
-            return;
+            SetToolbarPosition(result.ToolbarPosition);
+            AppSettings.SetString("ToolbarPosition", result.ToolbarPosition);
         }
-
-        var dialog = new OpenFileDialog
-        {
-            Title = "Select Claude Binary",
-            Filter = "Executable (*.exe)|*.exe|All Files (*.*)|*.*",
-            FileName = currentPath == "claude" ? "" : currentPath
-        };
-
-        if (dialog.ShowDialog() != true)
-            return;
-
-        ClaudeSession.ClaudeBinaryPath = dialog.FileName;
-        AppSettings.SetString("ClaudePath", dialog.FileName);
-        Log.Info($"ClaudePathOverride: set to '{dialog.FileName}'");
     }
 
-    private void OpenLogsFolder_Click(object sender, RoutedEventArgs e)
+    private void AppSettings_Click(object sender, RoutedEventArgs e)
     {
-        var logPath = Log.LogFilePath;
-        var folder = !string.IsNullOrEmpty(logPath)
-            ? Path.GetDirectoryName(logPath)
-            : null;
+        var currentClaudePath = AppSettings.GetString("ClaudePath");
 
-        if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder))
+        var result = Windows.AppSettingsDialog.Show(
+            this,
+            ThemeManager.CurrentTheme.Id,
+            _currentToolbarPosition,
+            currentClaudePath);
+
+        if (result == null) return;
+
+        if (result.ThemeId != ThemeManager.CurrentTheme.Id)
+            ThemeManager.ApplyTheme(result.ThemeId);
+
+        if (result.ToolbarPosition != _currentToolbarPosition)
         {
-            ThemedMessageBox.Show(this, "Logs folder not found.", "Open Logs",
-                MessageBoxButton.OK, MessageBoxImage.Warning);
-            return;
+            SetToolbarPosition(result.ToolbarPosition);
+            AppSettings.SetString("ToolbarPosition", result.ToolbarPosition);
         }
 
-        Process.Start(new ProcessStartInfo
+        var newClaudePath = string.IsNullOrEmpty(result.ClaudePath) ? "claude" : result.ClaudePath;
+        if (newClaudePath != ClaudeSession.ClaudeBinaryPath)
         {
-            FileName = folder,
-            UseShellExecute = true
-        });
+            ClaudeSession.ClaudeBinaryPath = newClaudePath;
+            AppSettings.SetString("ClaudePath", string.IsNullOrEmpty(result.ClaudePath) ? "" : result.ClaudePath);
+            Log.Info($"AppSettings: ClaudePath set to '{newClaudePath}'");
+        }
     }
 
     // --- Help Menu ---
@@ -2372,9 +2343,6 @@ public partial class MainWindow : Window
         if (position == _currentToolbarPosition)
             return;
 
-        foreach (var item in _toolbarPositionMenuItems)
-            item.IsChecked = false;
-
         Dock dock;
         Thickness borderThickness;
         Orientation orientation;
@@ -2385,25 +2353,21 @@ public partial class MainWindow : Window
                 dock = Dock.Top;
                 borderThickness = new Thickness(0, 0, 0, 1);
                 orientation = Orientation.Horizontal;
-                ToolbarTopMenu.IsChecked = true;
                 break;
             case "Bottom":
                 dock = Dock.Bottom;
                 borderThickness = new Thickness(0, 1, 0, 0);
                 orientation = Orientation.Horizontal;
-                ToolbarBottomMenu.IsChecked = true;
                 break;
             case "Left":
                 dock = Dock.Left;
                 borderThickness = new Thickness(0, 0, 1, 0);
                 orientation = Orientation.Vertical;
-                ToolbarLeftMenu.IsChecked = true;
                 break;
             case "Right":
                 dock = Dock.Right;
                 borderThickness = new Thickness(1, 0, 0, 0);
                 orientation = Orientation.Vertical;
-                ToolbarRightMenu.IsChecked = true;
                 break;
             default:
                 return;
@@ -2474,8 +2438,6 @@ public partial class MainWindow : Window
 
     private void OnThemeChanged(ThemeDescriptor theme)
     {
-        UpdateThemeMenuCheckmarks();
-
         // Update AvalonDock theme on all DockingManagers
         var dockTheme = theme.BaseVariant == ThemeBaseVariant.Dark
             ? (Theme)new Vs2013DarkTheme()
@@ -2520,64 +2482,6 @@ public partial class MainWindow : Window
 
         // Update taskbar icon with new theme accent bar
         UpdateTaskbarIcon();
-    }
-
-    private void PopulateThemeMenu()
-    {
-        ThemeMenu.Items.Clear();
-
-        // Dark themes group
-        ThemeMenu.Items.Add(new MenuItem
-        {
-            Header = "Dark Themes",
-            IsEnabled = false,
-            FontStyle = FontStyles.Italic
-        });
-
-        foreach (var theme in ThemeRegistry.All.Where(t => t.BaseVariant == ThemeBaseVariant.Dark))
-        {
-            var item = new MenuItem
-            {
-                Header = theme.DisplayName,
-                IsCheckable = true,
-                IsChecked = ThemeManager.CurrentTheme.Id == theme.Id,
-                Tag = theme.Id
-            };
-            item.Click += ThemeMenuItem_Click;
-            ThemeMenu.Items.Add(item);
-        }
-
-        ThemeMenu.Items.Add(new Separator());
-
-        // Light themes group
-        ThemeMenu.Items.Add(new MenuItem
-        {
-            Header = "Light Themes",
-            IsEnabled = false,
-            FontStyle = FontStyles.Italic
-        });
-
-        foreach (var theme in ThemeRegistry.All.Where(t => t.BaseVariant == ThemeBaseVariant.Light))
-        {
-            var item = new MenuItem
-            {
-                Header = theme.DisplayName,
-                IsCheckable = true,
-                IsChecked = ThemeManager.CurrentTheme.Id == theme.Id,
-                Tag = theme.Id
-            };
-            item.Click += ThemeMenuItem_Click;
-            ThemeMenu.Items.Add(item);
-        }
-    }
-
-    private void UpdateThemeMenuCheckmarks()
-    {
-        foreach (var item in ThemeMenu.Items.OfType<MenuItem>())
-        {
-            if (item.Tag is string themeId)
-                item.IsChecked = ThemeManager.CurrentTheme.Id == themeId;
-        }
     }
 
     // --- Claude Code plan usage (/status Usage) ---

--- a/src/AgentDock/MainWindow.xaml.cs
+++ b/src/AgentDock/MainWindow.xaml.cs
@@ -413,6 +413,11 @@ public partial class MainWindow : Window
     {
         // Log environment info for diagnostics
         Log.Info($"Prereq: OS={Environment.OSVersion}, .NET={Environment.Version}, 64-bit={Environment.Is64BitProcess}");
+        Log.Info($"Prereq: OSDescription='{System.Runtime.InteropServices.RuntimeInformation.OSDescription}', " +
+                 $"Framework='{System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}', " +
+                 $"Arch={System.Runtime.InteropServices.RuntimeInformation.OSArchitecture}");
+        Log.Info($"Prereq: DictationSupported={Services.DictationService.IsSupportedOnThisOS} " +
+                 $"(requires Win10 build 19041+)");
         Log.Info($"Prereq: User={Environment.UserName}, Machine={Environment.MachineName}");
 
         var results = new List<(string Name, bool Found, string Detail)>();

--- a/src/AgentDock/MainWindow.xaml.cs
+++ b/src/AgentDock/MainWindow.xaml.cs
@@ -322,12 +322,17 @@ public partial class MainWindow : Window
     private void AppSettings_Click(object sender, RoutedEventArgs e)
     {
         var currentClaudePath = AppSettings.GetString("ClaudePath");
+        var currentChannelStr = AppSettings.GetString("UpdateChannel", "Stable");
+        var currentChannel = Enum.TryParse<UpdateChannel>(currentChannelStr, ignoreCase: true, out var c)
+            ? c
+            : UpdateChannel.Stable;
 
         var result = Windows.AppSettingsDialog.Show(
             this,
             ThemeManager.CurrentTheme.Id,
             _currentToolbarPosition,
-            currentClaudePath);
+            currentClaudePath,
+            currentChannel);
 
         if (result == null) return;
 
@@ -346,6 +351,12 @@ public partial class MainWindow : Window
             ClaudeSession.ClaudeBinaryPath = newClaudePath;
             AppSettings.SetString("ClaudePath", string.IsNullOrEmpty(result.ClaudePath) ? "" : result.ClaudePath);
             Log.Info($"AppSettings: ClaudePath set to '{newClaudePath}'");
+        }
+
+        if (result.UpdateChannel != currentChannel)
+        {
+            AppSettings.SetString("UpdateChannel", result.UpdateChannel.ToString());
+            Log.Info($"AppSettings: UpdateChannel set to '{result.UpdateChannel}'");
         }
     }
 
@@ -673,7 +684,11 @@ public partial class MainWindow : Window
         Log.Info("UpdateCheck: skipping update check in Debug build");
         return;
 #else
-        var updateInfo = await System.Threading.Tasks.Task.Run(UpdateCheckService.CheckForUpdateAsync);
+        var channelStr = AppSettings.GetString("UpdateChannel", "Stable");
+        var channel = Enum.TryParse<UpdateChannel>(channelStr, ignoreCase: true, out var c)
+            ? c
+            : UpdateChannel.Stable;
+        var updateInfo = await System.Threading.Tasks.Task.Run(() => UpdateCheckService.CheckForUpdateAsync(channel));
         if (updateInfo == null)
             return;
 

--- a/src/AgentDock/MainWindow.xaml.cs
+++ b/src/AgentDock/MainWindow.xaml.cs
@@ -1363,6 +1363,14 @@ public partial class MainWindow : Window
                 gitStatusControl.RefreshStatus();
         };
 
+        // Clicking a file-path reference in the chat reveals + selects the file
+        // in the explorer; the existing FileSelected handler shows the preview.
+        aiChatControl.FileReferenceClicked += path =>
+        {
+            Log.Info($"FileReferenceClicked: {path}");
+            fileExplorerControl.RevealAndSelect(path);
+        };
+
         // Update AI Chat panel title when model is reported or when stats change
         aiChatControl.SessionModelChanged += _ => UpdateAiChatTitle(project, aiChatControl);
         aiChatControl.SessionStatsChanged += _ =>

--- a/src/AgentDock/MainWindow.xaml.cs
+++ b/src/AgentDock/MainWindow.xaml.cs
@@ -98,8 +98,16 @@ public partial class MainWindow : Window
         ThemeManager.ThemeChanged += OnThemeChanged;
         UpdateTaskbarIcon();
 
-        // Sync maximize/restore icon whenever window state changes (button click, double-click, aero snap, etc.)
-        StateChanged += (_, _) => UpdateMaximizeIcon();
+        // Sync maximize/restore icon whenever window state changes (button click, double-click, aero snap, etc.).
+        // Also grant any process permission to bring us back when we minimize — without this,
+        // a long-idle instance whose foreground privilege has expired can't be restored from
+        // the taskbar (the click plays a ding and the window stays minimized).
+        StateChanged += (_, _) =>
+        {
+            UpdateMaximizeIcon();
+            if (WindowState == WindowState.Minimized)
+                AllowSetForegroundWindow(ASFW_ANY);
+        };
         UpdateMaximizeIcon();
 
         // Restore saved toolbar position
@@ -196,6 +204,11 @@ public partial class MainWindow : Window
 
     [DllImport("user32.dll")]
     private static extern int SetWindowLong(IntPtr hwnd, int nIndex, int dwNewLong);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool AllowSetForegroundWindow(int dwProcessId);
+
+    private const int ASFW_ANY = -1;
 
     [StructLayout(LayoutKind.Sequential)]
     private struct POINT { public int X, Y; }

--- a/src/AgentDock/Models/ChatMessages.cs
+++ b/src/AgentDock/Models/ChatMessages.cs
@@ -1,0 +1,206 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Windows.Documents;
+using System.Windows.Threading;
+
+namespace AgentDock.Models;
+
+// Chat message view-models for the virtualizing ItemsControl.
+//
+// Design: past messages are facts — once finalized, they never change. They're
+// modelled as immutable records (no INPC, no virtual property dispatch, no
+// allocation on access). Only the *currently being built* messages mutate, and
+// only those types implement INotifyPropertyChanged. On finalize, a streaming
+// VM is replaced in the collection by its immutable record counterpart, after
+// which it has no event subscribers and no listeners — nothing to leak.
+
+public abstract class ChatMessageVm(Guid id)
+{
+    public Guid Id { get; } = id;
+}
+
+// --- Immutable finalized messages ---
+
+public sealed class UserMessage(Guid id, string text) : ChatMessageVm(id)
+{
+    public string Text { get; } = text;
+}
+
+/// <summary>
+/// A finalized assistant message. Past messages don't mutate — IsMarkdownView
+/// is part of the immutable identity; toggling the view replaces this VM in
+/// the collection with a new instance carrying the flipped flag. No INPC.
+///
+/// <see cref="Markdown"/> is the pre-rendered FlowDocument, built once at
+/// finalize time. The same document instance is re-attached to whichever
+/// MarkdownScrollViewer realizes its container — no markdown re-parse on
+/// scroll. May be null for single-line messages (rendered as plain text).
+/// </summary>
+public sealed class AssistantMessage(
+    Guid id,
+    string text,
+    bool isMarkdownView,
+    bool hasMarkdownToggle,
+    FlowDocument? markdown) : ChatMessageVm(id)
+{
+    public string Text { get; } = text;
+    public bool IsMarkdownView { get; } = isMarkdownView;
+    /// <summary>True for multi-line assistant text — the only case where the
+    /// source/rendered toggle button is meaningful (single-line messages have
+    /// nothing for the renderer to add).</summary>
+    public bool HasMarkdownToggle { get; } = hasMarkdownToggle;
+    public FlowDocument? Markdown { get; } = markdown;
+}
+
+public sealed class ThinkingMessage(Guid id, string text, bool isExpanded) : ChatMessageVm(id)
+{
+    public string Text { get; } = text;
+    public bool IsExpanded { get; } = isExpanded;
+}
+
+public sealed record ToolEntry(string Name, string FormattedInput);
+
+public sealed class ExecutionMessage(Guid id, IReadOnlyList<ToolEntry> tools, bool isExpanded) : ChatMessageVm(id)
+{
+    public IReadOnlyList<ToolEntry> Tools { get; } = tools;
+    public bool IsExpanded { get; } = isExpanded;
+}
+
+public sealed class SystemMessage(Guid id, string text, bool isWarning) : ChatMessageVm(id)
+{
+    public string Text { get; } = text;
+    public bool IsWarning { get; } = isWarning;
+}
+
+/// <summary>
+/// Transient placeholder shown after the user sends a message, until the first
+/// delta or content_block_start arrives. Removed from the collection once
+/// real content begins streaming.
+/// </summary>
+public sealed class WaitingMessage(Guid id) : ChatMessageVm(id);
+
+// --- Live messages (only these need INPC) ---
+
+/// <summary>
+/// Base for the two streaming text VMs (assistant and thinking). Deltas are
+/// accumulated in a <see cref="StringBuilder"/> and flushed to <see cref="Text"/>
+/// at ~30 fps via a <see cref="DispatcherTimer"/>, so a fast stream produces
+/// one binding-update per frame instead of one per delta.
+/// </summary>
+public abstract class StreamingTextMessage(Guid id) : ChatMessageVm(id), INotifyPropertyChanged
+{
+    private readonly StringBuilder _buffer = new();
+    private DispatcherTimer? _flushTimer;
+    private string _text = "";
+
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            // Authoritative reset (e.g. when the final assistant message arrives
+            // with the full text — supersedes anything we'd accumulated).
+            _flushTimer?.Stop();
+            _flushTimer = null;
+            _buffer.Clear();
+            if (_text == value) return;
+            _text = value;
+            OnPropertyChanged(nameof(Text));
+        }
+    }
+
+    /// <summary>Append a stream delta. Coalesced to ~30 fps via the throttle timer.</summary>
+    public void AppendText(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return;
+        _buffer.Append(text);
+        if (_flushTimer != null) return;
+
+        _flushTimer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromMilliseconds(33)
+        };
+        _flushTimer.Tick += (_, _) => Flush();
+        _flushTimer.Start();
+    }
+
+    /// <summary>
+    /// Drains the buffer into <see cref="Text"/> and fires a single
+    /// <see cref="PropertyChanged"/>. Called automatically by the timer and
+    /// must also be called from <c>FinalizeStreaming</c> so the trailing
+    /// delta isn't dropped when the turn completes between timer ticks.
+    /// </summary>
+    public void Flush()
+    {
+        _flushTimer?.Stop();
+        _flushTimer = null;
+        if (_buffer.Length == 0) return;
+        _text += _buffer.ToString();
+        _buffer.Clear();
+        OnPropertyChanged(nameof(Text));
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+/// <summary>
+/// The currently-streaming assistant text. On turn completion it's replaced
+/// in the messages collection by an immutable <see cref="AssistantMessage"/>.
+/// </summary>
+public sealed class StreamingAssistantMessage(Guid id) : StreamingTextMessage(id);
+
+/// <summary>
+/// The currently-streaming thinking text. Most models (e.g. claude-opus-4-7
+/// in summary mode) don't send any thinking_delta events, in which case this
+/// VM is never created. When a model does stream thinking, the VM is added
+/// to the collection on the first delta and replaced by an immutable
+/// <see cref="ThinkingMessage"/> when the content_block_stop arrives.
+/// </summary>
+public sealed class StreamingThinkingMessage(Guid id) : StreamingTextMessage(id);
+
+/// <summary>
+/// Execution bubble currently being filled with tool_use entries for the
+/// active turn. Replaced by an immutable <see cref="ExecutionMessage"/>
+/// when the turn finishes.
+/// </summary>
+public sealed class BuildingExecutionMessage(Guid id) : ChatMessageVm(id), INotifyPropertyChanged
+{
+    public ObservableCollection<ToolEntry> Tools { get; } = [];
+
+    private bool _isExpanded;
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set { if (_isExpanded != value) { _isExpanded = value; OnPropertyChanged(); } }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+/// <summary>
+/// Inactivity warning bubble. <see cref="ElapsedText"/> ticks once per second
+/// while shown. <see cref="OnWait"/> and <see cref="OnKill"/> are invoked by
+/// the bound buttons.
+/// </summary>
+public sealed class InactivityWarning(Guid id) : ChatMessageVm(id), INotifyPropertyChanged
+{
+    private string _elapsedText = "";
+    public string ElapsedText
+    {
+        get => _elapsedText;
+        set { if (_elapsedText != value) { _elapsedText = value; OnPropertyChanged(); } }
+    }
+
+    public Action? OnWait { get; init; }
+    public Action? OnKill { get; init; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/src/AgentDock/Models/ProjectGroup.cs
+++ b/src/AgentDock/Models/ProjectGroup.cs
@@ -1,0 +1,13 @@
+namespace AgentDock.Models;
+
+/// <summary>
+/// A named grouping of project tabs (a "meta tab"). When two or more groups exist,
+/// the meta tab bar appears above the project tab strip and only the active group's
+/// projects are visible.
+/// </summary>
+public class ProjectGroup
+{
+    public required string Id { get; init; }
+    public string Name { get; set; } = "";
+    public int Order { get; set; }
+}

--- a/src/AgentDock/Models/ProjectInfo.cs
+++ b/src/AgentDock/Models/ProjectInfo.cs
@@ -22,4 +22,10 @@ public class ProjectInfo
     /// </summary>
     public string DisplayName =>
         string.IsNullOrWhiteSpace(CustomName) ? FolderName : CustomName!;
+
+    /// <summary>
+    /// Id of the <see cref="ProjectGroup"/> this project belongs to.
+    /// Null when no grouping is in use for the current workspace.
+    /// </summary>
+    public string? GroupId { get; set; }
 }

--- a/src/AgentDock/Models/WorkspaceFile.cs
+++ b/src/AgentDock/Models/WorkspaceFile.cs
@@ -7,11 +7,22 @@ namespace AgentDock.Models;
 /// </summary>
 public class WorkspaceFile
 {
-    public int Version { get; set; } = 1;
+    public int Version { get; set; } = 2;
     public string Theme { get; set; } = "Dark";
     public string ToolbarPosition { get; set; } = "Top";
     public string? ActiveProjectPath { get; set; }
     public List<WorkspaceProject> Projects { get; set; } = [];
+
+    /// <summary>
+    /// Project tab groups (meta tabs). Empty when the workspace has no grouping —
+    /// in that case every project is implicitly ungrouped and the meta tab bar is hidden.
+    /// </summary>
+    public List<ProjectGroup> Groups { get; set; } = [];
+
+    /// <summary>
+    /// Id of the group whose projects are visible. Null when no grouping is in use.
+    /// </summary>
+    public string? ActiveGroupId { get; set; }
 }
 
 /// <summary>
@@ -21,4 +32,9 @@ public class WorkspaceProject
 {
     public string FolderPath { get; set; } = "";
     public string? DockingLayout { get; set; }
+
+    /// <summary>
+    /// Id of the <see cref="ProjectGroup"/> this project belongs to, or null when no grouping is in use.
+    /// </summary>
+    public string? GroupId { get; set; }
 }

--- a/src/AgentDock/Services/ClaudeSession.cs
+++ b/src/AgentDock/Services/ClaudeSession.cs
@@ -468,7 +468,11 @@ public class ClaudeSession : IDisposable
                 // Reset inactivity watchdog on each line of output
                 ResetInactivityTimer();
 
-                Log.Info($"ClaudeSession STDOUT: {(line.Length > 500 ? line[..500] + "..." : line)}");
+                // Skip logging streaming-token deltas — they fire dozens of times per second
+                // during a long response and were producing 100+ MB log files. The events are
+                // still parsed and dispatched to the UI; we just don't write them to disk.
+                if (!line.StartsWith("{\"type\":\"stream_event\"", StringComparison.Ordinal))
+                    Log.Info($"ClaudeSession STDOUT: {(line.Length > 500 ? line[..500] + "..." : line)}");
 
                 try
                 {

--- a/src/AgentDock/Services/DictationService.cs
+++ b/src/AgentDock/Services/DictationService.cs
@@ -1,0 +1,180 @@
+using System.Globalization;
+using Windows.Globalization;
+using Windows.Media.SpeechRecognition;
+
+namespace AgentDock.Services;
+
+public enum DictationState
+{
+    Idle,
+    Starting,
+    Listening,
+    Stopping,
+    Error
+}
+
+/// <summary>
+/// Wraps Windows.Media.SpeechRecognition for continuous-dictation in a WPF-friendly
+/// shape. Events fire on a thread-pool thread; callers must marshal to the UI thread.
+/// </summary>
+public class DictationService : IDisposable
+{
+    private SpeechRecognizer? _recognizer;
+    private bool _starting;
+    private bool _listening;
+
+    /// <summary>Final phrase recognized. May fire many times during a session.</summary>
+    public event Action<string>? TextRecognized;
+
+    public event Action<DictationState>? StateChanged;
+
+    /// <summary>Human-readable error message; <see cref="State"/> is also set to Error.</summary>
+    public event Action<string>? ErrorOccurred;
+
+    public DictationState State { get; private set; } = DictationState.Idle;
+
+    public bool IsActive => _listening || _starting;
+
+    /// <summary>
+    /// True when this OS supports the WinRT speech-recognition API used here.
+    /// Windows 10 version 2004 (build 19041) introduced the recognizer the modern
+    /// dictation engine ships with; older Win10 builds get a graceful "no mic".
+    /// </summary>
+    public static bool IsSupportedOnThisOS
+        => OperatingSystem.IsWindowsVersionAtLeast(10, 0, 19041);
+
+    public async Task ToggleAsync()
+    {
+        if (IsActive) await StopAsync();
+        else await StartAsync();
+    }
+
+    public async Task StartAsync()
+    {
+        if (IsActive) return;
+        if (!IsSupportedOnThisOS)
+        {
+            SetError("Dictation requires Windows 10 version 2004 (build 19041) or later.");
+            return;
+        }
+        _starting = true;
+        SetState(DictationState.Starting);
+
+        try
+        {
+            if (_recognizer == null)
+            {
+                var lang = ResolveLanguage();
+                _recognizer = lang != null ? new SpeechRecognizer(lang) : new SpeechRecognizer();
+                _recognizer.Constraints.Add(new SpeechRecognitionTopicConstraint(
+                    SpeechRecognitionScenario.Dictation, "dictation"));
+                _recognizer.ContinuousRecognitionSession.ResultGenerated += OnResult;
+                _recognizer.ContinuousRecognitionSession.Completed += OnCompleted;
+
+                var compile = await _recognizer.CompileConstraintsAsync();
+                if (compile.Status != SpeechRecognitionResultStatus.Success)
+                {
+                    SetError($"Speech recognizer could not initialize ({compile.Status}). " +
+                             "Install a Windows Speech language pack via Settings → Time & Language → Speech.");
+                    DisposeRecognizer();
+                    return;
+                }
+            }
+
+            await _recognizer.ContinuousRecognitionSession.StartAsync();
+            _listening = true;
+            SetState(DictationState.Listening);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            SetError("Microphone access denied. Allow microphone for desktop apps in " +
+                     "Settings → Privacy & Security → Microphone.");
+            DisposeRecognizer();
+        }
+        catch (Exception ex)
+        {
+            SetError(ex.Message);
+            DisposeRecognizer();
+        }
+        finally
+        {
+            _starting = false;
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        if (!_listening || _recognizer == null) return;
+        SetState(DictationState.Stopping);
+        try
+        {
+            await _recognizer.ContinuousRecognitionSession.StopAsync();
+        }
+        catch
+        {
+            // Stop racing with end-of-session is benign — just fall through.
+        }
+        finally
+        {
+            _listening = false;
+            if (State != DictationState.Error)
+                SetState(DictationState.Idle);
+        }
+    }
+
+    private void OnResult(SpeechContinuousRecognitionSession session,
+        SpeechContinuousRecognitionResultGeneratedEventArgs args)
+    {
+        var text = args.Result?.Text;
+        if (!string.IsNullOrWhiteSpace(text))
+            TextRecognized?.Invoke(text);
+    }
+
+    private void OnCompleted(SpeechContinuousRecognitionSession session,
+        SpeechContinuousRecognitionCompletedEventArgs args)
+    {
+        _listening = false;
+        if (State != DictationState.Error)
+            SetState(DictationState.Idle);
+    }
+
+    private void SetState(DictationState state)
+    {
+        if (state == State) return;
+        State = state;
+        StateChanged?.Invoke(state);
+    }
+
+    private void SetError(string message)
+    {
+        State = DictationState.Error;
+        StateChanged?.Invoke(DictationState.Error);
+        ErrorOccurred?.Invoke(message);
+    }
+
+    private static Language? ResolveLanguage()
+    {
+        // Prefer the user's UI culture if Windows has a recognizer for it; otherwise let
+        // SpeechRecognizer pick its default.
+        try
+        {
+            var tag = CultureInfo.CurrentUICulture.IetfLanguageTag;
+            if (string.IsNullOrEmpty(tag)) return null;
+            return new Language(tag);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void DisposeRecognizer()
+    {
+        if (_recognizer == null) return;
+        try { _recognizer.Dispose(); } catch { }
+        _recognizer = null;
+        _listening = false;
+    }
+
+    public void Dispose() => DisposeRecognizer();
+}

--- a/src/AgentDock/Services/MarkdownHelper.cs
+++ b/src/AgentDock/Services/MarkdownHelper.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Documents;
 using ICSharpCode.AvalonEdit;
@@ -18,6 +19,23 @@ public static partial class MarkdownHelper
     [GeneratedRegex(@"(?<!\*)\*\[([^\]]+)\]\(([^)]+)\)\*(?!\*)")]
     private static partial Regex ItalicLinkRegex();
 
+    // Leading "# vX.Y.Z" heading + trailing blank line (for release-notes files where
+    // the version is already shown by the surrounding chrome / GitHub release page).
+    [GeneratedRegex(@"\A#\s+v?\d+(\.\d+)+[^\r\n]*\r?\n(\r?\n)?")]
+    private static partial Regex LeadingVersionHeadingRegex();
+
+    // **...** containing at least one inline atom (code span or link). MdXaml parses
+    // those atoms before bold, which leaves the ** delimiters orphaned around the
+    // atom and renders them as literal text. We split the bold around each atom.
+    [GeneratedRegex(@"\*\*([^*\n]*?(?:`[^`\n]+`|\[[^\]\n]+\]\([^)\n]+\))[^*\n]*?)\*\*")]
+    private static partial Regex BoldContainingInlineRegex();
+
+    [GeneratedRegex(@"`[^`\n]+`|\[[^\]\n]+\]\([^)\n]+\)")]
+    private static partial Regex InlineAtomRegex();
+
+    [GeneratedRegex(@"^(\s*)(.*?)(\s*)$", RegexOptions.Singleline)]
+    private static partial Regex TrimWsRegex();
+
     /// <summary>
     /// Pre-processes markdown to fix patterns that MdXaml cannot parse.
     /// MdXaml parses links before bold/italic, so <c>**[text](url)**</c> leaves
@@ -27,8 +45,53 @@ public static partial class MarkdownHelper
     {
         markdown = BoldLinkRegex().Replace(markdown, "[**$1**]($2)");
         markdown = ItalicLinkRegex().Replace(markdown, "[*$1*]($2)");
+        markdown = FixBoldAcrossInlineAtoms(markdown);
         return markdown;
     }
+
+    /// <summary>
+    /// Rewrites <c>**text `code` text**</c> as <c>**text** `code` **text**</c> so that
+    /// MdXaml can pair the bold delimiters. Also handles partial-link cases like
+    /// <c>**See [foo](url) more**</c>. Trims whitespace at split boundaries to satisfy
+    /// CommonMark flanking rules.
+    /// </summary>
+    private static string FixBoldAcrossInlineAtoms(string markdown)
+    {
+        return BoldContainingInlineRegex().Replace(markdown, m =>
+        {
+            var inner = m.Groups[1].Value;
+            var sb = new StringBuilder();
+            var lastEnd = 0;
+            foreach (Match atom in InlineAtomRegex().Matches(inner))
+            {
+                EmitBoldTextSegment(inner.Substring(lastEnd, atom.Index - lastEnd), sb);
+                sb.Append(atom.Value);
+                lastEnd = atom.Index + atom.Length;
+            }
+            EmitBoldTextSegment(inner.Substring(lastEnd), sb);
+            return sb.ToString();
+        });
+    }
+
+    private static void EmitBoldTextSegment(string segment, StringBuilder sb)
+    {
+        if (segment.Length == 0) return;
+        var m = TrimWsRegex().Match(segment);
+        var lead = m.Groups[1].Value;
+        var core = m.Groups[2].Value;
+        var trail = m.Groups[3].Value;
+        if (lead.Length > 0) sb.Append(lead);
+        if (core.Length > 0) sb.Append("**").Append(core).Append("**");
+        if (trail.Length > 0) sb.Append(trail);
+    }
+
+    /// <summary>
+    /// Strips a leading <c># vX.Y.Z</c> heading (and the blank line after it) from
+    /// release-notes markdown, since dialog chrome / GitHub release pages already
+    /// display the version separately.
+    /// </summary>
+    public static string StripLeadingVersionHeading(string markdown)
+        => LeadingVersionHeadingRegex().Replace(markdown, "", 1);
 
     /// <summary>
     /// Applies theme colors to fenced code blocks in a rendered MdXaml FlowDocument.

--- a/src/AgentDock/Services/MarkdownHelper.cs
+++ b/src/AgentDock/Services/MarkdownHelper.cs
@@ -1,6 +1,8 @@
+using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Documents;
+using System.Windows.Input;
 using ICSharpCode.AvalonEdit;
 using MdXaml;
 
@@ -35,6 +37,14 @@ public static partial class MarkdownHelper
 
     [GeneratedRegex(@"^(\s*)(.*?)(\s*)$", RegexOptions.Singleline)]
     private static partial Regex TrimWsRegex();
+
+    // Path candidate: optional ./ or .\ prefix, optional drive letter, one or more
+    // separator-terminated segments, then a final filename with extension, optional :line ref.
+    [GeneratedRegex(@"\G(?:\.[\\/])?(?:[A-Za-z]:[\\/])?(?:[\w.\-]+[\\/])+[\w\-.]+\.[A-Za-z][\w]*(?::\d+)?")]
+    private static partial Regex PathCandidateRegex();
+
+    public const string FileLinkScheme = "agentdock-file";
+    private const string FileLinkPrefix = "agentdock-file:///";
 
     /// <summary>
     /// Pre-processes markdown to fix patterns that MdXaml cannot parse.
@@ -140,5 +150,247 @@ public static partial class MarkdownHelper
                 foreach (var child in item.Blocks)
                     ApplyCodeBlockStyle(child, bg, fg);
         }
+    }
+
+    /// <summary>
+    /// Rewrites file-path references in <paramref name="markdown"/> as markdown links
+    /// using the <c>agentdock-file://</c> scheme. Only paths containing a directory
+    /// separator that resolve to an existing file (under <paramref name="projectRoot"/>
+    /// or absolute) are linked. Skips fenced code blocks and existing markdown links.
+    /// </summary>
+    public static string LinkifyPaths(string markdown, string projectRoot)
+    {
+        if (string.IsNullOrEmpty(markdown) || string.IsNullOrEmpty(projectRoot))
+            return markdown;
+
+        var sb = new StringBuilder(markdown.Length + 64);
+        var inFence = false;
+        var i = 0;
+
+        while (i < markdown.Length)
+        {
+            // Fenced code block delimiter at line start — toggle and skip the line.
+            if ((i == 0 || markdown[i - 1] == '\n') && IsFenceAt(markdown, i))
+            {
+                var nl = markdown.IndexOf('\n', i);
+                if (nl < 0) { sb.Append(markdown, i, markdown.Length - i); break; }
+                sb.Append(markdown, i, nl - i + 1);
+                i = nl + 1;
+                inFence = !inFence;
+                continue;
+            }
+
+            if (inFence)
+            {
+                var nl = markdown.IndexOf('\n', i);
+                if (nl < 0) { sb.Append(markdown, i, markdown.Length - i); break; }
+                sb.Append(markdown, i, nl - i + 1);
+                i = nl + 1;
+                continue;
+            }
+
+            // Skip past existing markdown links [text](url) so we don't double-wrap.
+            if (markdown[i] == '[')
+            {
+                var endBracket = markdown.IndexOf(']', i + 1);
+                if (endBracket > i && endBracket + 1 < markdown.Length && markdown[endBracket + 1] == '(')
+                {
+                    var endParen = markdown.IndexOf(')', endBracket + 2);
+                    if (endParen > endBracket)
+                    {
+                        sb.Append(markdown, i, endParen - i + 1);
+                        i = endParen + 1;
+                        continue;
+                    }
+                }
+            }
+
+            // Inline backtick span — wrap the entire span as a link if the inner text
+            // resolves to a file. Inline code spans don't span lines per CommonMark.
+            if (markdown[i] == '`')
+            {
+                var nlIdx = markdown.IndexOf('\n', i + 1);
+                var endTick = markdown.IndexOf('`', i + 1);
+                if (endTick > i && (nlIdx < 0 || endTick < nlIdx))
+                {
+                    var inner = markdown.Substring(i + 1, endTick - i - 1);
+                    if (TryResolvePath(inner.Trim(), projectRoot, out var abs))
+                    {
+                        sb.Append('[').Append('`').Append(inner).Append('`').Append("](")
+                            .Append(ToFileLinkUri(abs)).Append(')');
+                        i = endTick + 1;
+                        continue;
+                    }
+                    sb.Append(markdown, i, endTick - i + 1);
+                    i = endTick + 1;
+                    continue;
+                }
+            }
+
+            // Try to match a path starting here. Previous char must be a non-path boundary.
+            if (i == 0 || IsPathBoundary(markdown[i - 1]))
+            {
+                var match = PathCandidateRegex().Match(markdown, i);
+                if (match.Success && match.Index == i)
+                {
+                    var text = match.Value;
+                    var next = i + text.Length;
+                    if (next >= markdown.Length || IsPathBoundary(markdown[next]))
+                    {
+                        if (TryResolvePath(text, projectRoot, out var abs))
+                        {
+                            sb.Append('[').Append(EscapeLinkText(text)).Append("](")
+                                .Append(ToFileLinkUri(abs)).Append(')');
+                            i = next;
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            sb.Append(markdown[i]);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Walks <paramref name="doc"/> for hyperlinks with the <c>agentdock-file://</c>
+    /// scheme and wires their navigation to <paramref name="onClick"/>, passing the
+    /// decoded absolute path.
+    /// </summary>
+    public static void WireFileLinks(FlowDocument? doc, Action<string> onClick)
+    {
+        if (doc == null) return;
+        foreach (var link in EnumerateHyperlinks(doc))
+        {
+            if (link.NavigateUri == null) continue;
+            var abs = FromFileLinkUri(link.NavigateUri.OriginalString);
+            if (abs == null) continue;
+            link.Cursor = Cursors.Hand;
+            link.RequestNavigate += (_, e) =>
+            {
+                e.Handled = true;
+                onClick(abs);
+            };
+        }
+    }
+
+    private static bool IsFenceAt(string s, int i)
+        => i + 2 < s.Length && s[i] == '`' && s[i + 1] == '`' && s[i + 2] == '`';
+
+    private static bool IsPathBoundary(char c)
+        => !(char.IsLetterOrDigit(c) || c == '_' || c == '/' || c == '\\');
+
+    private static string EscapeLinkText(string text)
+        => text.Replace("\\", "\\\\").Replace("]", "\\]");
+
+    private static string ToFileLinkUri(string absolutePath)
+        => FileLinkPrefix + Uri.EscapeDataString(absolutePath);
+
+    private static string? FromFileLinkUri(string uriString)
+    {
+        if (!uriString.StartsWith(FileLinkPrefix, StringComparison.Ordinal)) return null;
+        return Uri.UnescapeDataString(uriString.Substring(FileLinkPrefix.Length));
+    }
+
+    private static bool TryResolvePath(string text, string projectRoot, out string absolute)
+    {
+        absolute = "";
+        if (string.IsNullOrWhiteSpace(text)) return false;
+
+        // Strip optional :line ref. Don't strip the colon in a Windows drive prefix.
+        var lastColon = text.LastIndexOf(':');
+        if (lastColon > 1 && lastColon < text.Length - 1 && AllDigits(text, lastColon + 1))
+            text = text.Substring(0, lastColon);
+
+        if (text.IndexOf('/') < 0 && text.IndexOf('\\') < 0) return false;
+
+        string candidate;
+        if (Path.IsPathRooted(text))
+        {
+            candidate = text;
+        }
+        else
+        {
+            if (text.StartsWith("./", StringComparison.Ordinal) || text.StartsWith(".\\", StringComparison.Ordinal))
+                text = text.Substring(2);
+            candidate = Path.Combine(projectRoot, text);
+        }
+
+        try
+        {
+            if (File.Exists(candidate))
+            {
+                absolute = Path.GetFullPath(candidate);
+                return true;
+            }
+        }
+        catch
+        {
+            // Invalid path characters etc. — treat as no match.
+        }
+        return false;
+    }
+
+    private static bool AllDigits(string s, int start)
+    {
+        for (var k = start; k < s.Length; k++)
+            if (!char.IsDigit(s[k])) return false;
+        return start < s.Length;
+    }
+
+    private static IEnumerable<Hyperlink> EnumerateHyperlinks(FlowDocument doc)
+    {
+        foreach (var b in doc.Blocks)
+            foreach (var h in EnumerateHyperlinks(b))
+                yield return h;
+    }
+
+    private static IEnumerable<Hyperlink> EnumerateHyperlinks(Block block)
+    {
+        switch (block)
+        {
+            case Paragraph p:
+                foreach (var inl in p.Inlines)
+                    foreach (var h in EnumerateHyperlinksInline(inl))
+                        yield return h;
+                break;
+            case Section s:
+                foreach (var b in s.Blocks)
+                    foreach (var h in EnumerateHyperlinks(b))
+                        yield return h;
+                break;
+            case List list:
+                foreach (var item in list.ListItems)
+                    foreach (var b in item.Blocks)
+                        foreach (var h in EnumerateHyperlinks(b))
+                            yield return h;
+                break;
+            case Table table:
+                foreach (var rg in table.RowGroups)
+                    foreach (var row in rg.Rows)
+                        foreach (var cell in row.Cells)
+                            foreach (var b in cell.Blocks)
+                                foreach (var h in EnumerateHyperlinks(b))
+                                    yield return h;
+                break;
+        }
+    }
+
+    private static IEnumerable<Hyperlink> EnumerateHyperlinksInline(Inline inline)
+    {
+        // Hyperlink derives from Span — check it first so we don't recurse into its
+        // inner inlines twice.
+        if (inline is Hyperlink h)
+        {
+            yield return h;
+            yield break;
+        }
+        if (inline is Span span)
+            foreach (var child in span.Inlines)
+                foreach (var hh in EnumerateHyperlinksInline(child))
+                    yield return hh;
     }
 }

--- a/src/AgentDock/Services/MarkdownHelper.cs
+++ b/src/AgentDock/Services/MarkdownHelper.cs
@@ -129,6 +129,44 @@ public static partial class MarkdownHelper
         ApplyCodeBlockTheme(viewer.Document);
     }
 
+    /// <summary>
+    /// Builds a standalone <see cref="FlowDocument"/> from markdown source.
+    /// Used by the chat to cache a per-message rendered document at finalize
+    /// time, so scrolling past and back doesn't re-parse markdown.
+    ///
+    /// Internally instantiates a throwaway <see cref="MarkdownScrollViewer"/>
+    /// to drive MdXaml's parser, then detaches the document so it can be
+    /// attached to a real viewer later. The temp viewer is GC-eligible on return.
+    /// </summary>
+    /// <param name="markdown">Raw markdown source — preprocessing is handled internally.</param>
+    /// <param name="markdownStyle">Optional <see cref="FlowDocument"/> style (foreground, font, etc.).
+    /// Pass the same style the live viewer uses so the cached document renders identically.</param>
+    /// <param name="projectPath">Project root for path-link resolution. Pass empty to skip.</param>
+    /// <param name="onFileLinkClicked">Click handler for resolved file references in the rendered document.</param>
+    public static FlowDocument BuildDocument(
+        string markdown,
+        System.Windows.Style? markdownStyle,
+        string projectPath,
+        Action<string>? onFileLinkClicked)
+    {
+        var linkified = string.IsNullOrEmpty(projectPath) ? markdown : LinkifyPaths(markdown, projectPath);
+        var preProcessed = PreProcess(linkified);
+
+        var tmp = new MarkdownScrollViewer { MarkdownStyle = markdownStyle };
+        tmp.Markdown = preProcessed;
+        var doc = tmp.Document ?? new FlowDocument();
+
+        ApplyCodeBlockTheme(doc);
+        if (onFileLinkClicked != null)
+            WireFileLinks(doc, onFileLinkClicked);
+
+        // Detach from the temp viewer so the document can be re-parented to a
+        // real viewer when the chat container materializes.
+        tmp.Document = null;
+
+        return doc;
+    }
+
     private static void ApplyCodeBlockStyle(
         Block block, System.Windows.Media.Brush bg, System.Windows.Media.Brush fg)
     {

--- a/src/AgentDock/Services/ReleaseNotesService.cs
+++ b/src/AgentDock/Services/ReleaseNotesService.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Reflection;
+
+namespace AgentDock.Services;
+
+/// <summary>
+/// Reads release-notes markdown bundled with the assembly as embedded resources.
+/// Files in <c>docs/release-notes/v*.md</c> are embedded with logical name
+/// <c>ReleaseNotes/v{X.Y.Z}.md</c>.
+/// </summary>
+public static class ReleaseNotesService
+{
+    /// <summary>
+    /// Loads the markdown body for the given version (e.g. "0.9.0").
+    /// Returns null if the resource is not embedded.
+    /// </summary>
+    public static string? GetNotesForVersion(string version)
+    {
+        var resourceName = $"ReleaseNotes/v{version}.md";
+        try
+        {
+            using var stream = typeof(ReleaseNotesService).Assembly.GetManifestResourceStream(resourceName);
+            if (stream == null)
+            {
+                Log.Info($"ReleaseNotes: no embedded notes for v{version}");
+                return null;
+            }
+
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"ReleaseNotes: failed to read v{version} — {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/src/AgentDock/Services/UpdateCheckService.cs
+++ b/src/AgentDock/Services/UpdateCheckService.cs
@@ -8,7 +8,7 @@ namespace AgentDock.Services;
 /// <summary>
 /// Checks GitHub releases for newer versions and orchestrates the update process.
 /// </summary>
-public record UpdateInfo(string Version, string DownloadUrl, string ReleaseName);
+public record UpdateInfo(string Version, string DownloadUrl, string ReleaseName, string Notes);
 
 public static class UpdateCheckService
 {
@@ -106,9 +106,12 @@ public static class UpdateCheckService
             }
 
             var releaseName = root.GetProperty("name").GetString() ?? tagName;
+            var notes = root.TryGetProperty("body", out var bodyProp)
+                ? bodyProp.GetString() ?? ""
+                : "";
 
             Log.Info($"UpdateCheck: update available — {remoteVersionStr} (current: {App.Version})");
-            return new UpdateInfo(remoteVersionStr, downloadUrl, releaseName);
+            return new UpdateInfo(remoteVersionStr, downloadUrl, releaseName, notes);
         }
         catch (TaskCanceledException)
         {

--- a/src/AgentDock/Services/UpdateCheckService.cs
+++ b/src/AgentDock/Services/UpdateCheckService.cs
@@ -6,14 +6,27 @@ using System.Text.Json;
 namespace AgentDock.Services;
 
 /// <summary>
+/// Update release channel.
+/// </summary>
+/// <remarks>
+/// <para><b>Stable</b> (default) only ever surfaces non-prerelease GitHub releases —
+/// the <c>/releases/latest</c> endpoint excludes prereleases server-side.</para>
+/// <para><b>Beta</b> opts in to prerelease tags (e.g. <c>v0.10.0-beta.1</c>) and
+/// auto-updates between successive betas and to the eventual stable release.
+/// Use this on machines that should track upcoming builds for testing.</para>
+/// </remarks>
+public enum UpdateChannel { Stable, Beta }
+
+/// <summary>
 /// Checks GitHub releases for newer versions and orchestrates the update process.
 /// </summary>
 public record UpdateInfo(string Version, string DownloadUrl, string ReleaseName, string Notes);
 
 public static class UpdateCheckService
 {
-    private const string ReleasesApiUrl =
-        "https://api.github.com/repos/develorem/agent-dock/releases/latest";
+    private const string ApiBase = "https://api.github.com/repos/develorem/agent-dock";
+    private const string LatestReleaseUrl = ApiBase + "/releases/latest";
+    private const string AllReleasesUrl = ApiBase + "/releases?per_page=30";
 
     private const string InstallerAssetPrefix = "AgentDock-";
     private const string InstallerAssetSuffix = "-setup.exe";
@@ -30,88 +43,48 @@ public static class UpdateCheckService
     }
 
     /// <summary>
-    /// Checks GitHub releases for a newer version.
+    /// Checks GitHub releases for a newer version on the given <paramref name="channel"/>.
     /// Returns UpdateInfo if a newer version exists, null otherwise.
     /// Never throws — returns null on any error.
     /// </summary>
-    public static async Task<UpdateInfo?> CheckForUpdateAsync()
+    public static async Task<UpdateInfo?> CheckForUpdateAsync(UpdateChannel channel = UpdateChannel.Stable)
     {
         try
         {
-            Log.Info("UpdateCheck: checking for updates");
+            Log.Info($"UpdateCheck: checking for updates (channel={channel})");
 
-            using var response = await Http.GetAsync(ReleasesApiUrl);
-            if (!response.IsSuccessStatusCode)
-            {
-                Log.Warn($"UpdateCheck: API returned {response.StatusCode}");
-                return null;
-            }
-
-            var json = await response.Content.ReadAsStringAsync();
-            using var doc = JsonDocument.Parse(json);
-            var root = doc.RootElement;
-
-            var tagName = root.GetProperty("tag_name").GetString();
-            if (string.IsNullOrEmpty(tagName))
-                return null;
-
-            var remoteVersionStr = tagName.TrimStart('v');
-
-            // Skip pre-releases (the /latest endpoint excludes them, but belt-and-suspenders)
-            if (remoteVersionStr.Contains('-'))
-            {
-                Log.Info($"UpdateCheck: skipping pre-release {tagName}");
-                return null;
-            }
-
-            if (!Version.TryParse(remoteVersionStr, out var remoteVersion))
-            {
-                Log.Warn($"UpdateCheck: could not parse version '{remoteVersionStr}'");
-                return null;
-            }
-
-            var currentVersionStr = App.Version.Split(['-', '+'])[0];
-            if (!Version.TryParse(currentVersionStr, out var currentVersion))
+            var current = SemVer.TryParse(App.Version);
+            if (current is null)
             {
                 Log.Warn($"UpdateCheck: could not parse current version '{App.Version}'");
                 return null;
             }
 
-            if (remoteVersion <= currentVersion)
+            var candidate = channel == UpdateChannel.Beta
+                ? await FindBestBetaReleaseAsync()
+                : await FindLatestStableReleaseAsync();
+
+            if (candidate is null)
+                return null;
+
+            if (candidate.Version.CompareTo(current) <= 0)
             {
-                Log.Info($"UpdateCheck: current {currentVersion} >= remote {remoteVersion}, no update");
+                Log.Info($"UpdateCheck: current {current} >= remote {candidate.Version}, no update");
                 return null;
             }
 
-            // Find the setup.exe asset
-            string? downloadUrl = null;
-            if (root.TryGetProperty("assets", out var assets))
-            {
-                foreach (var asset in assets.EnumerateArray())
-                {
-                    var name = asset.GetProperty("name").GetString() ?? "";
-                    if (name.StartsWith(InstallerAssetPrefix, StringComparison.OrdinalIgnoreCase)
-                        && name.EndsWith(InstallerAssetSuffix, StringComparison.OrdinalIgnoreCase))
-                    {
-                        downloadUrl = asset.GetProperty("browser_download_url").GetString();
-                        break;
-                    }
-                }
-            }
-
-            if (string.IsNullOrEmpty(downloadUrl))
+            if (string.IsNullOrEmpty(candidate.DownloadUrl))
             {
                 Log.Warn("UpdateCheck: no setup.exe asset found in release");
                 return null;
             }
 
-            var releaseName = root.GetProperty("name").GetString() ?? tagName;
-            var notes = root.TryGetProperty("body", out var bodyProp)
-                ? bodyProp.GetString() ?? ""
-                : "";
-
-            Log.Info($"UpdateCheck: update available — {remoteVersionStr} (current: {App.Version})");
-            return new UpdateInfo(remoteVersionStr, downloadUrl, releaseName, notes);
+            Log.Info($"UpdateCheck: update available — {candidate.Version} (current: {current})");
+            return new UpdateInfo(
+                candidate.Version.ToString(),
+                candidate.DownloadUrl,
+                candidate.ReleaseName,
+                candidate.Notes);
         }
         catch (TaskCanceledException)
         {
@@ -129,6 +102,107 @@ public static class UpdateCheckService
             return null;
         }
     }
+
+    /// <summary>
+    /// GET /releases/latest — returns the latest non-prerelease release.
+    /// </summary>
+    private static async Task<ReleaseCandidate?> FindLatestStableReleaseAsync()
+    {
+        using var response = await Http.GetAsync(LatestReleaseUrl);
+        if (!response.IsSuccessStatusCode)
+        {
+            Log.Warn($"UpdateCheck: API returned {response.StatusCode}");
+            return null;
+        }
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        return ExtractCandidate(root, requireStable: true);
+    }
+
+    /// <summary>
+    /// GET /releases — scans all releases (including prereleases) and returns the
+    /// one with the highest SemVer.
+    /// </summary>
+    private static async Task<ReleaseCandidate?> FindBestBetaReleaseAsync()
+    {
+        using var response = await Http.GetAsync(AllReleasesUrl);
+        if (!response.IsSuccessStatusCode)
+        {
+            Log.Warn($"UpdateCheck: API returned {response.StatusCode}");
+            return null;
+        }
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        if (root.ValueKind != JsonValueKind.Array)
+            return null;
+
+        ReleaseCandidate? best = null;
+        foreach (var release in root.EnumerateArray())
+        {
+            // Skip drafts — not visible to anyone yet
+            if (release.TryGetProperty("draft", out var draft) && draft.GetBoolean())
+                continue;
+
+            var c = ExtractCandidate(release, requireStable: false);
+            if (c is null) continue;
+
+            if (best is null || c.Version.CompareTo(best.Version) > 0)
+                best = c;
+        }
+        return best;
+    }
+
+    /// <summary>
+    /// Parses a GitHub release JSON element into a <see cref="ReleaseCandidate"/>.
+    /// Returns null if the release isn't usable (missing/unparseable tag, etc.)
+    /// or if <paramref name="requireStable"/> and the tag has a prerelease suffix.
+    /// </summary>
+    private static ReleaseCandidate? ExtractCandidate(JsonElement release, bool requireStable)
+    {
+        var tag = release.TryGetProperty("tag_name", out var t) ? t.GetString() : null;
+        if (string.IsNullOrEmpty(tag))
+            return null;
+
+        var version = SemVer.TryParse(tag);
+        if (version is null)
+        {
+            Log.Warn($"UpdateCheck: could not parse tag '{tag}'");
+            return null;
+        }
+
+        if (requireStable && version.IsPrerelease)
+        {
+            Log.Info($"UpdateCheck: skipping pre-release {tag}");
+            return null;
+        }
+
+        string? downloadUrl = null;
+        if (release.TryGetProperty("assets", out var assets))
+        {
+            foreach (var asset in assets.EnumerateArray())
+            {
+                var name = asset.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "";
+                if (name.StartsWith(InstallerAssetPrefix, StringComparison.OrdinalIgnoreCase)
+                    && name.EndsWith(InstallerAssetSuffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    downloadUrl = asset.TryGetProperty("browser_download_url", out var u) ? u.GetString() : null;
+                    break;
+                }
+            }
+        }
+
+        var releaseName = release.TryGetProperty("name", out var nameProp) ? nameProp.GetString() ?? tag : tag;
+        var notes = release.TryGetProperty("body", out var bodyProp) ? bodyProp.GetString() ?? "" : "";
+
+        return new ReleaseCandidate(version, downloadUrl ?? "", releaseName, notes);
+    }
+
+    private sealed record ReleaseCandidate(SemVer Version, string DownloadUrl, string ReleaseName, string Notes);
 
     /// <summary>
     /// Downloads the installer to a temp file with progress reporting.
@@ -221,4 +295,87 @@ public static class UpdateCheckService
 
         System.Windows.Application.Current.Shutdown();
     }
+}
+
+/// <summary>
+/// Minimal SemVer 2.0.0 parser and comparer — enough to order our release tags
+/// correctly, including prerelease ordering rules (no-prerelease &gt; any prerelease,
+/// numeric identifiers compared numerically, etc.). Not a full SemVer implementation
+/// — build metadata after '+' is stripped, and identifier comparison only handles
+/// the patterns we tag with (numeric and lowercase alphanumeric).
+/// </summary>
+internal sealed class SemVer(int major, int minor, int patch, string? prerelease) : IComparable<SemVer>
+{
+    public int Major { get; } = major;
+    public int Minor { get; } = minor;
+    public int Patch { get; } = patch;
+    public string? Prerelease { get; } = prerelease;
+    public bool IsPrerelease => Prerelease != null;
+
+    public static SemVer? TryParse(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+
+        var s = raw.TrimStart('v', 'V');
+
+        // Strip +build metadata (per SemVer it doesn't affect precedence).
+        var plus = s.IndexOf('+');
+        if (plus >= 0) s = s[..plus];
+
+        var dash = s.IndexOf('-');
+        var prerelease = dash >= 0 ? s[(dash + 1)..] : null;
+        var versionPart = dash >= 0 ? s[..dash] : s;
+
+        var parts = versionPart.Split('.');
+        if (parts.Length < 3) return null;
+        if (!int.TryParse(parts[0], out var major)) return null;
+        if (!int.TryParse(parts[1], out var minor)) return null;
+        if (!int.TryParse(parts[2], out var patch)) return null;
+
+        return new SemVer(major, minor, patch, prerelease);
+    }
+
+    public int CompareTo(SemVer? other)
+    {
+        if (other is null) return 1;
+
+        var c = Major.CompareTo(other.Major);
+        if (c != 0) return c;
+        c = Minor.CompareTo(other.Minor);
+        if (c != 0) return c;
+        c = Patch.CompareTo(other.Patch);
+        if (c != 0) return c;
+
+        // SemVer rule: a version with prerelease has lower precedence than one without.
+        if (Prerelease == null && other.Prerelease == null) return 0;
+        if (Prerelease == null) return 1;
+        if (other.Prerelease == null) return -1;
+
+        var a = Prerelease.Split('.');
+        var b = other.Prerelease.Split('.');
+        var len = Math.Min(a.Length, b.Length);
+        for (int i = 0; i < len; i++)
+        {
+            var aIsNum = int.TryParse(a[i], out var an);
+            var bIsNum = int.TryParse(b[i], out var bn);
+            if (aIsNum && bIsNum)
+            {
+                c = an.CompareTo(bn);
+                if (c != 0) return c;
+            }
+            else if (aIsNum) return -1; // numeric identifiers have lower precedence than alphanumeric
+            else if (bIsNum) return 1;
+            else
+            {
+                c = string.CompareOrdinal(a[i], b[i]);
+                if (c != 0) return c;
+            }
+        }
+        // All compared identifiers equal — longer prerelease string has higher precedence.
+        return a.Length.CompareTo(b.Length);
+    }
+
+    public override string ToString()
+        => Prerelease is null ? $"{Major}.{Minor}.{Patch}" : $"{Major}.{Minor}.{Patch}-{Prerelease}";
 }

--- a/src/AgentDock/Themes/EmberTheme.xaml
+++ b/src/AgentDock/Themes/EmberTheme.xaml
@@ -110,6 +110,14 @@
     <SolidColorBrush x:Key="DiffRemovedBackground" Color="{StaticResource DiffRemovedColor}" />
     <SolidColorBrush x:Key="DiffHunkHeaderBackground" Color="{StaticResource DiffHunkHeaderColor}" />
 
+    <!-- JSON syntax -->
+    <SolidColorBrush x:Key="JsonKeyForeground" Color="#DCBE7E" />
+    <SolidColorBrush x:Key="JsonStringForeground" Color="#E0A878" />
+    <SolidColorBrush x:Key="JsonNumberForeground" Color="#B0C580" />
+    <SolidColorBrush x:Key="JsonBooleanForeground" Color="#D4854A" />
+    <SolidColorBrush x:Key="JsonNullForeground" Color="#D4854A" />
+    <SolidColorBrush x:Key="JsonPunctuationForeground" Color="#7A7065" />
+
     <!-- Markdown rendering -->
     <SolidColorBrush x:Key="MarkdownHeadingForeground" Color="#D4854A" />
     <SolidColorBrush x:Key="MarkdownCodeBackground" Color="#231C18" />

--- a/src/AgentDock/Themes/FrostTheme.xaml
+++ b/src/AgentDock/Themes/FrostTheme.xaml
@@ -110,6 +110,14 @@
     <SolidColorBrush x:Key="DiffRemovedBackground" Color="{StaticResource DiffRemovedColor}" />
     <SolidColorBrush x:Key="DiffHunkHeaderBackground" Color="{StaticResource DiffHunkHeaderColor}" />
 
+    <!-- JSON syntax -->
+    <SolidColorBrush x:Key="JsonKeyForeground" Color="#0451A5" />
+    <SolidColorBrush x:Key="JsonStringForeground" Color="#A31515" />
+    <SolidColorBrush x:Key="JsonNumberForeground" Color="#098658" />
+    <SolidColorBrush x:Key="JsonBooleanForeground" Color="#0000FF" />
+    <SolidColorBrush x:Key="JsonNullForeground" Color="#0000FF" />
+    <SolidColorBrush x:Key="JsonPunctuationForeground" Color="#777777" />
+
     <!-- Markdown rendering -->
     <SolidColorBrush x:Key="MarkdownHeadingForeground" Color="#1F2328" />
     <SolidColorBrush x:Key="MarkdownCodeBackground" Color="#F0F0F0" />

--- a/src/AgentDock/Themes/MidnightTheme.xaml
+++ b/src/AgentDock/Themes/MidnightTheme.xaml
@@ -110,6 +110,14 @@
     <SolidColorBrush x:Key="DiffRemovedBackground" Color="{StaticResource DiffRemovedColor}" />
     <SolidColorBrush x:Key="DiffHunkHeaderBackground" Color="{StaticResource DiffHunkHeaderColor}" />
 
+    <!-- JSON syntax -->
+    <SolidColorBrush x:Key="JsonKeyForeground" Color="#79C0FF" />
+    <SolidColorBrush x:Key="JsonStringForeground" Color="#A5D6FF" />
+    <SolidColorBrush x:Key="JsonNumberForeground" Color="#FFA657" />
+    <SolidColorBrush x:Key="JsonBooleanForeground" Color="#FF7B72" />
+    <SolidColorBrush x:Key="JsonNullForeground" Color="#FF7B72" />
+    <SolidColorBrush x:Key="JsonPunctuationForeground" Color="#8B949E" />
+
     <!-- Markdown rendering -->
     <SolidColorBrush x:Key="MarkdownHeadingForeground" Color="#58A6FF" />
     <SolidColorBrush x:Key="MarkdownCodeBackground" Color="#161B22" />

--- a/src/AgentDock/Themes/ObsidianTheme.xaml
+++ b/src/AgentDock/Themes/ObsidianTheme.xaml
@@ -110,6 +110,14 @@
     <SolidColorBrush x:Key="DiffRemovedBackground" Color="{StaticResource DiffRemovedColor}" />
     <SolidColorBrush x:Key="DiffHunkHeaderBackground" Color="{StaticResource DiffHunkHeaderColor}" />
 
+    <!-- JSON syntax -->
+    <SolidColorBrush x:Key="JsonKeyForeground" Color="#9CDCFE" />
+    <SolidColorBrush x:Key="JsonStringForeground" Color="#CE9178" />
+    <SolidColorBrush x:Key="JsonNumberForeground" Color="#B5CEA8" />
+    <SolidColorBrush x:Key="JsonBooleanForeground" Color="#569CD6" />
+    <SolidColorBrush x:Key="JsonNullForeground" Color="#569CD6" />
+    <SolidColorBrush x:Key="JsonPunctuationForeground" Color="#808080" />
+
     <!-- Markdown rendering -->
     <SolidColorBrush x:Key="MarkdownHeadingForeground" Color="#569CD6" />
     <SolidColorBrush x:Key="MarkdownCodeBackground" Color="#2D2D30" />

--- a/src/AgentDock/Themes/ParchmentTheme.xaml
+++ b/src/AgentDock/Themes/ParchmentTheme.xaml
@@ -110,6 +110,14 @@
     <SolidColorBrush x:Key="DiffRemovedBackground" Color="{StaticResource DiffRemovedColor}" />
     <SolidColorBrush x:Key="DiffHunkHeaderBackground" Color="{StaticResource DiffHunkHeaderColor}" />
 
+    <!-- JSON syntax -->
+    <SolidColorBrush x:Key="JsonKeyForeground" Color="#6B4C11" />
+    <SolidColorBrush x:Key="JsonStringForeground" Color="#8B5A2B" />
+    <SolidColorBrush x:Key="JsonNumberForeground" Color="#2D7A20" />
+    <SolidColorBrush x:Key="JsonBooleanForeground" Color="#7030A0" />
+    <SolidColorBrush x:Key="JsonNullForeground" Color="#7030A0" />
+    <SolidColorBrush x:Key="JsonPunctuationForeground" Color="#9C8C6E" />
+
     <!-- Markdown rendering -->
     <SolidColorBrush x:Key="MarkdownHeadingForeground" Color="#6B4C11" />
     <SolidColorBrush x:Key="MarkdownCodeBackground" Color="#F0E8DC" />

--- a/src/AgentDock/Themes/SakuraTheme.xaml
+++ b/src/AgentDock/Themes/SakuraTheme.xaml
@@ -110,6 +110,14 @@
     <SolidColorBrush x:Key="DiffRemovedBackground" Color="{StaticResource DiffRemovedColor}" />
     <SolidColorBrush x:Key="DiffHunkHeaderBackground" Color="{StaticResource DiffHunkHeaderColor}" />
 
+    <!-- JSON syntax -->
+    <SolidColorBrush x:Key="JsonKeyForeground" Color="#B8357A" />
+    <SolidColorBrush x:Key="JsonStringForeground" Color="#A0532A" />
+    <SolidColorBrush x:Key="JsonNumberForeground" Color="#2A7A30" />
+    <SolidColorBrush x:Key="JsonBooleanForeground" Color="#7040A0" />
+    <SolidColorBrush x:Key="JsonNullForeground" Color="#7040A0" />
+    <SolidColorBrush x:Key="JsonPunctuationForeground" Color="#B591A0" />
+
     <!-- Markdown rendering -->
     <SolidColorBrush x:Key="MarkdownHeadingForeground" Color="#8A2050" />
     <SolidColorBrush x:Key="MarkdownCodeBackground" Color="#FDE8EE" />

--- a/src/AgentDock/Windows/AboutWindow.xaml
+++ b/src/AgentDock/Windows/AboutWindow.xaml
@@ -71,6 +71,13 @@
                 </Hyperlink>
             </TextBlock>
             <TextBlock FontSize="13" Margin="0,0,0,4">
+                <Hyperlink NavigateUri="https://github.com/develorem/agent-dock/releases"
+                           RequestNavigate="Hyperlink_RequestNavigate">
+                    <Run Foreground="{DynamicResource HelpLinkForeground}"
+                         Text="Release Notes &#x2197;" />
+                </Hyperlink>
+            </TextBlock>
+            <TextBlock FontSize="13" Margin="0,0,0,4">
                 <Hyperlink NavigateUri="https://github.com/develorem"
                            RequestNavigate="Hyperlink_RequestNavigate">
                     <Run Foreground="{DynamicResource HelpLinkForeground}"

--- a/src/AgentDock/Windows/AppSettingsDialog.xaml
+++ b/src/AgentDock/Windows/AppSettingsDialog.xaml
@@ -141,6 +141,7 @@
                              SelectionChanged="NavList_SelectionChanged">
                         <ListBoxItem Tag="appearance" IsSelected="True">Appearance</ListBoxItem>
                         <ListBoxItem Tag="integrations">Integrations</ListBoxItem>
+                        <ListBoxItem Tag="updates">Updates</ListBoxItem>
                         <ListBoxItem Tag="diagnostics">Diagnostics</ListBoxItem>
                     </ListBox>
                 </Border>
@@ -211,6 +212,24 @@
                             </DockPanel>
                             <TextBlock Text="Leave blank to use 'claude' from your system PATH. Set this if you've installed Claude Code in a custom location."
                                        Style="{StaticResource FieldHint}" />
+                        </StackPanel>
+
+                        <!-- Updates -->
+                        <StackPanel x:Name="UpdatesSection" Visibility="Collapsed">
+                            <TextBlock Text="Updates" Style="{StaticResource SectionHeader}" />
+
+                            <TextBlock Text="Release Channel" Style="{StaticResource FieldLabel}" />
+                            <ComboBox x:Name="UpdateChannelCombo"
+                                      Height="28"
+                                      FontSize="13"
+                                      VerticalContentAlignment="Center"
+                                      Margin="0,0,0,4">
+                                <ComboBoxItem Content="Stable" Tag="Stable" />
+                                <ComboBoxItem Content="Beta (pre-releases)" Tag="Beta" />
+                            </ComboBox>
+                            <TextBlock Style="{StaticResource FieldHint}"
+                                       TextWrapping="Wrap"
+                                       Text="Stable only auto-updates to official releases. Beta opts in to test builds tagged like v0.10.0-beta.1 — use this on machines you've volunteered to test pre-releases with. Beta still auto-updates to the final stable release when it ships." />
                         </StackPanel>
 
                         <!-- Diagnostics -->

--- a/src/AgentDock/Windows/AppSettingsDialog.xaml
+++ b/src/AgentDock/Windows/AppSettingsDialog.xaml
@@ -1,0 +1,251 @@
+<Window x:Class="AgentDock.Windows.AppSettingsDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="App Settings"
+        Width="680" Height="480"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Icon="/Assets/agentdock.png"
+        Background="Transparent">
+
+    <Window.Resources>
+        <Style x:Key="DialogButton" TargetType="{x:Type Button}">
+            <Setter Property="MinWidth" Value="76" />
+            <Setter Property="Height" Value="28" />
+            <Setter Property="Padding" Value="12,0" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Background" Value="{DynamicResource HelpCardBackground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource HelpCardBorderBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background"
+                                        Value="{DynamicResource MenuHighlightBackground}" />
+                            </Trigger>
+                            <Trigger Property="IsDefault" Value="True">
+                                <Setter TargetName="Bd" Property="BorderBrush"
+                                        Value="{DynamicResource TabButtonActiveBorderBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="NavListItem" TargetType="{x:Type ListBoxItem}">
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Padding" Value="12,8" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                Padding="{TemplateBinding Padding}"
+                                CornerRadius="3"
+                                Margin="0,1">
+                            <ContentPresenter />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background"
+                                        Value="{DynamicResource MenuHighlightBackground}" />
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Bd" Property="Background"
+                                        Value="{DynamicResource ExplorerSelectedBackground}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="SectionHeader" TargetType="{x:Type TextBlock}">
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Margin" Value="0,0,0,12" />
+        </Style>
+
+        <Style x:Key="FieldLabel" TargetType="{x:Type TextBlock}">
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Margin" Value="0,0,0,4" />
+        </Style>
+
+        <Style x:Key="FieldHint" TargetType="{x:Type TextBlock}">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="Opacity" Value="0.7" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Margin" Value="0,0,0,16" />
+        </Style>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource HelpBackground}"
+            BorderBrush="{DynamicResource ToolbarBorderBrush}"
+            BorderThickness="1"
+            CornerRadius="4">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Border Grid.Row="0"
+                    Background="{DynamicResource TitleBarBackground}"
+                    CornerRadius="4,4,0,0"
+                    Padding="12,8"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <TextBlock Text="App Settings"
+                           FontSize="12"
+                           FontWeight="SemiBold"
+                           Foreground="{DynamicResource TitleBarForeground}" />
+            </Border>
+
+            <Grid Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="160" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <Border Grid.Column="0"
+                        BorderBrush="{DynamicResource ToolbarBorderBrush}"
+                        BorderThickness="0,0,1,0"
+                        Padding="8,8">
+                    <ListBox x:Name="NavList"
+                             Background="Transparent"
+                             BorderThickness="0"
+                             ItemContainerStyle="{StaticResource NavListItem}"
+                             SelectionChanged="NavList_SelectionChanged">
+                        <ListBoxItem Tag="appearance" IsSelected="True">Appearance</ListBoxItem>
+                        <ListBoxItem Tag="integrations">Integrations</ListBoxItem>
+                        <ListBoxItem Tag="diagnostics">Diagnostics</ListBoxItem>
+                    </ListBox>
+                </Border>
+
+                <ScrollViewer Grid.Column="1"
+                              VerticalScrollBarVisibility="Auto"
+                              Padding="20,16">
+                    <Grid>
+                        <!-- Appearance -->
+                        <StackPanel x:Name="AppearanceSection">
+                            <TextBlock Text="Appearance" Style="{StaticResource SectionHeader}" />
+
+                            <TextBlock Text="Default Theme" Style="{StaticResource FieldLabel}" />
+                            <ComboBox x:Name="ThemeCombo"
+                                      Height="28"
+                                      FontSize="13"
+                                      VerticalContentAlignment="Center"
+                                      Margin="0,0,0,4">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding DisplayName}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                            <TextBlock Text="Used when launching without a workspace, or as the starting point for new workspaces."
+                                       Style="{StaticResource FieldHint}" />
+
+                            <TextBlock Text="Default Toolbar Position" Style="{StaticResource FieldLabel}" />
+                            <ComboBox x:Name="ToolbarPositionCombo"
+                                      Height="28"
+                                      FontSize="13"
+                                      VerticalContentAlignment="Center"
+                                      Margin="0,0,0,4">
+                                <ComboBoxItem Content="Top" Tag="Top" />
+                                <ComboBoxItem Content="Left" Tag="Left" />
+                                <ComboBoxItem Content="Right" Tag="Right" />
+                                <ComboBoxItem Content="Bottom" Tag="Bottom" />
+                            </ComboBox>
+                            <TextBlock Text="Where the project tab toolbar sits in the main window."
+                                       Style="{StaticResource FieldHint}" />
+                        </StackPanel>
+
+                        <!-- Integrations -->
+                        <StackPanel x:Name="IntegrationsSection" Visibility="Collapsed">
+                            <TextBlock Text="Integrations" Style="{StaticResource SectionHeader}" />
+
+                            <TextBlock Text="Claude Path Override" Style="{StaticResource FieldLabel}" />
+                            <DockPanel Margin="0,0,0,4">
+                                <Button DockPanel.Dock="Right"
+                                        Content="Reset"
+                                        Style="{StaticResource DialogButton}"
+                                        Click="ResetClaudePath_Click"
+                                        Margin="6,0,0,0" />
+                                <Button DockPanel.Dock="Right"
+                                        Content="Browse..."
+                                        Style="{StaticResource DialogButton}"
+                                        Click="BrowseClaudePath_Click"
+                                        Margin="6,0,0,0" />
+                                <TextBox x:Name="ClaudePathTextBox"
+                                         Height="28"
+                                         FontSize="12"
+                                         VerticalContentAlignment="Center"
+                                         Foreground="{DynamicResource HelpForeground}"
+                                         Background="{DynamicResource HelpCardBackground}"
+                                         BorderBrush="{DynamicResource HelpCardBorderBrush}"
+                                         BorderThickness="1"
+                                         Padding="6,0" />
+                            </DockPanel>
+                            <TextBlock Text="Leave blank to use 'claude' from your system PATH. Set this if you've installed Claude Code in a custom location."
+                                       Style="{StaticResource FieldHint}" />
+                        </StackPanel>
+
+                        <!-- Diagnostics -->
+                        <StackPanel x:Name="DiagnosticsSection" Visibility="Collapsed">
+                            <TextBlock Text="Diagnostics" Style="{StaticResource SectionHeader}" />
+
+                            <TextBlock Text="Logs" Style="{StaticResource FieldLabel}" />
+                            <Button Content="Open Logs Folder"
+                                    Style="{StaticResource DialogButton}"
+                                    Click="OpenLogsFolder_Click"
+                                    HorizontalAlignment="Left"
+                                    Margin="0,0,0,4" />
+                            <TextBlock x:Name="LogsPathText"
+                                       Style="{StaticResource FieldHint}" />
+                        </StackPanel>
+                    </Grid>
+                </ScrollViewer>
+            </Grid>
+
+            <Border Grid.Row="2"
+                    BorderBrush="{DynamicResource ToolbarBorderBrush}"
+                    BorderThickness="0,1,0,0"
+                    Padding="16,12">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Content="OK"
+                            Style="{StaticResource DialogButton}"
+                            IsDefault="True"
+                            Click="OkButton_Click"
+                            Margin="0,0,8,0" />
+                    <Button Content="Cancel"
+                            Style="{StaticResource DialogButton}"
+                            IsCancel="True"
+                            Click="CancelButton_Click" />
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/AgentDock/Windows/AppSettingsDialog.xaml.cs
+++ b/src/AgentDock/Windows/AppSettingsDialog.xaml.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using AgentDock.Models;
+using AgentDock.Services;
+using Microsoft.Win32;
+
+namespace AgentDock.Windows;
+
+public partial class AppSettingsDialog : Window
+{
+    public class Result
+    {
+        public string ThemeId { get; set; } = "";
+        public string ToolbarPosition { get; set; } = "Top";
+        public string ClaudePath { get; set; } = "";
+    }
+
+    public Result? Outcome { get; private set; }
+
+    private readonly StackPanel[] _sections;
+
+    private AppSettingsDialog(string currentThemeId, string currentToolbarPosition, string currentClaudePath)
+    {
+        InitializeComponent();
+        _sections = [AppearanceSection, IntegrationsSection, DiagnosticsSection];
+
+        ThemeCombo.ItemsSource = ThemeRegistry.All;
+        ThemeCombo.SelectedItem =
+            ThemeRegistry.FindById(currentThemeId) ?? ThemeRegistry.Default;
+
+        foreach (ComboBoxItem item in ToolbarPositionCombo.Items)
+        {
+            if ((string)item.Tag == currentToolbarPosition)
+            {
+                ToolbarPositionCombo.SelectedItem = item;
+                break;
+            }
+        }
+        if (ToolbarPositionCombo.SelectedItem == null)
+            ToolbarPositionCombo.SelectedIndex = 0;
+
+        // Empty / "claude" means default — show empty so the user knows it's the default.
+        ClaudePathTextBox.Text = currentClaudePath is "" or "claude" ? "" : currentClaudePath;
+
+        var logFile = Log.LogFilePath;
+        LogsPathText.Text = !string.IsNullOrEmpty(logFile) && Path.GetDirectoryName(logFile) is { } dir
+            ? $"Folder: {dir}"
+            : "Log folder not yet created.";
+    }
+
+    public static Result? Show(Window owner, string currentThemeId, string currentToolbarPosition, string currentClaudePath)
+    {
+        var dlg = new AppSettingsDialog(currentThemeId, currentToolbarPosition, currentClaudePath) { Owner = owner };
+        return dlg.ShowDialog() == true ? dlg.Outcome : null;
+    }
+
+    private void NavList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (NavList.SelectedItem is not ListBoxItem item || item.Tag is not string tag)
+            return;
+
+        foreach (var section in _sections)
+            section.Visibility = Visibility.Collapsed;
+
+        var target = tag switch
+        {
+            "integrations" => IntegrationsSection,
+            "diagnostics" => DiagnosticsSection,
+            _ => AppearanceSection
+        };
+        target.Visibility = Visibility.Visible;
+    }
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        => DragMove();
+
+    private void BrowseClaudePath_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new OpenFileDialog
+        {
+            Title = "Select Claude Binary",
+            Filter = "Executable (*.exe)|*.exe|All Files (*.*)|*.*",
+            FileName = ClaudePathTextBox.Text
+        };
+
+        if (dialog.ShowDialog(this) == true)
+            ClaudePathTextBox.Text = dialog.FileName;
+    }
+
+    private void ResetClaudePath_Click(object sender, RoutedEventArgs e)
+    {
+        ClaudePathTextBox.Text = "";
+    }
+
+    private void OpenLogsFolder_Click(object sender, RoutedEventArgs e)
+    {
+        var logPath = Log.LogFilePath;
+        var folder = !string.IsNullOrEmpty(logPath) ? Path.GetDirectoryName(logPath) : null;
+        if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder))
+        {
+            ThemedMessageBox.Show(this, "Logs folder not found.", "Open Logs",
+                MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = folder,
+            UseShellExecute = true
+        });
+    }
+
+    private void OkButton_Click(object sender, RoutedEventArgs e)
+    {
+        var theme = ThemeCombo.SelectedItem as ThemeDescriptor ?? ThemeRegistry.Default;
+        var toolbar = (ToolbarPositionCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "Top";
+
+        Outcome = new Result
+        {
+            ThemeId = theme.Id,
+            ToolbarPosition = toolbar,
+            ClaudePath = ClaudePathTextBox.Text.Trim()
+        };
+        DialogResult = true;
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+}

--- a/src/AgentDock/Windows/AppSettingsDialog.xaml.cs
+++ b/src/AgentDock/Windows/AppSettingsDialog.xaml.cs
@@ -16,16 +16,21 @@ public partial class AppSettingsDialog : Window
         public string ThemeId { get; set; } = "";
         public string ToolbarPosition { get; set; } = "Top";
         public string ClaudePath { get; set; } = "";
+        public UpdateChannel UpdateChannel { get; set; } = UpdateChannel.Stable;
     }
 
     public Result? Outcome { get; private set; }
 
     private readonly StackPanel[] _sections;
 
-    private AppSettingsDialog(string currentThemeId, string currentToolbarPosition, string currentClaudePath)
+    private AppSettingsDialog(
+        string currentThemeId,
+        string currentToolbarPosition,
+        string currentClaudePath,
+        UpdateChannel currentChannel)
     {
         InitializeComponent();
-        _sections = [AppearanceSection, IntegrationsSection, DiagnosticsSection];
+        _sections = [AppearanceSection, IntegrationsSection, UpdatesSection, DiagnosticsSection];
 
         ThemeCombo.ItemsSource = ThemeRegistry.All;
         ThemeCombo.SelectedItem =
@@ -45,15 +50,32 @@ public partial class AppSettingsDialog : Window
         // Empty / "claude" means default — show empty so the user knows it's the default.
         ClaudePathTextBox.Text = currentClaudePath is "" or "claude" ? "" : currentClaudePath;
 
+        var channelTag = currentChannel.ToString();
+        foreach (ComboBoxItem item in UpdateChannelCombo.Items)
+        {
+            if ((string)item.Tag == channelTag)
+            {
+                UpdateChannelCombo.SelectedItem = item;
+                break;
+            }
+        }
+        if (UpdateChannelCombo.SelectedItem == null)
+            UpdateChannelCombo.SelectedIndex = 0;
+
         var logFile = Log.LogFilePath;
         LogsPathText.Text = !string.IsNullOrEmpty(logFile) && Path.GetDirectoryName(logFile) is { } dir
             ? $"Folder: {dir}"
             : "Log folder not yet created.";
     }
 
-    public static Result? Show(Window owner, string currentThemeId, string currentToolbarPosition, string currentClaudePath)
+    public static Result? Show(
+        Window owner,
+        string currentThemeId,
+        string currentToolbarPosition,
+        string currentClaudePath,
+        UpdateChannel currentChannel)
     {
-        var dlg = new AppSettingsDialog(currentThemeId, currentToolbarPosition, currentClaudePath) { Owner = owner };
+        var dlg = new AppSettingsDialog(currentThemeId, currentToolbarPosition, currentClaudePath, currentChannel) { Owner = owner };
         return dlg.ShowDialog() == true ? dlg.Outcome : null;
     }
 
@@ -68,6 +90,7 @@ public partial class AppSettingsDialog : Window
         var target = tag switch
         {
             "integrations" => IntegrationsSection,
+            "updates" => UpdatesSection,
             "diagnostics" => DiagnosticsSection,
             _ => AppearanceSection
         };
@@ -117,12 +140,17 @@ public partial class AppSettingsDialog : Window
     {
         var theme = ThemeCombo.SelectedItem as ThemeDescriptor ?? ThemeRegistry.Default;
         var toolbar = (ToolbarPositionCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "Top";
+        var channelTag = (UpdateChannelCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "Stable";
+        var channel = Enum.TryParse<UpdateChannel>(channelTag, ignoreCase: true, out var c)
+            ? c
+            : UpdateChannel.Stable;
 
         Outcome = new Result
         {
             ThemeId = theme.Id,
             ToolbarPosition = toolbar,
-            ClaudePath = ClaudePathTextBox.Text.Trim()
+            ClaudePath = ClaudePathTextBox.Text.Trim(),
+            UpdateChannel = channel
         };
         DialogResult = true;
     }

--- a/src/AgentDock/Windows/UpdateDialog.xaml
+++ b/src/AgentDock/Windows/UpdateDialog.xaml
@@ -1,9 +1,10 @@
 <Window x:Class="AgentDock.Windows.UpdateDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mdxaml="clr-namespace:MdXaml;assembly=MdXaml"
         Title="Update Available"
         SizeToContent="WidthAndHeight"
-        MinWidth="380" MaxWidth="440"
+        MinWidth="420" MaxWidth="560"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         WindowStyle="None"
@@ -61,6 +62,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" /> <!-- Title bar -->
                 <RowDefinition Height="Auto" /> <!-- Content -->
+                <RowDefinition Height="Auto" /> <!-- Release notes -->
                 <RowDefinition Height="Auto" /> <!-- Progress bar -->
                 <RowDefinition Height="Auto" /> <!-- Buttons -->
             </Grid.RowDefinitions>
@@ -134,8 +136,40 @@
                 </Border>
             </StackPanel>
 
+            <!-- Release notes (collapsed if no body) -->
+            <Border x:Name="NotesPanel" Grid.Row="2"
+                    Margin="20,0,20,16"
+                    Background="{DynamicResource HelpCardBackground}"
+                    BorderBrush="{DynamicResource HelpCardBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="3"
+                    Visibility="Collapsed">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0"
+                               Text="What's new"
+                               FontSize="12"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource HelpHeadingForeground}"
+                               Margin="14,10,14,4" />
+
+                    <mdxaml:MarkdownScrollViewer x:Name="NotesViewer"
+                                                 Grid.Row="1"
+                                                 MaxHeight="260"
+                                                 Background="Transparent"
+                                                 Foreground="{DynamicResource HelpForeground}"
+                                                 MarkdownStyle="{StaticResource BaseMarkdownStyle}"
+                                                 VerticalScrollBarVisibility="Auto"
+                                                 Padding="14,2,14,10" />
+                </Grid>
+            </Border>
+
             <!-- Download progress (initially collapsed) -->
-            <StackPanel x:Name="ProgressPanel" Grid.Row="2"
+            <StackPanel x:Name="ProgressPanel" Grid.Row="3"
                         Margin="20,0,20,16"
                         Visibility="Collapsed">
                 <ProgressBar x:Name="DownloadProgress"
@@ -152,7 +186,7 @@
             </StackPanel>
 
             <!-- Buttons -->
-            <StackPanel Grid.Row="3"
+            <StackPanel Grid.Row="4"
                         Orientation="Horizontal"
                         HorizontalAlignment="Right"
                         Margin="20,4,20,16">

--- a/src/AgentDock/Windows/UpdateDialog.xaml.cs
+++ b/src/AgentDock/Windows/UpdateDialog.xaml.cs
@@ -17,6 +17,13 @@ public partial class UpdateDialog : Window
 
         CurrentVersionText.Text = $"v{App.Version}";
         NewVersionText.Text = $"v{updateInfo.Version}";
+
+        if (!string.IsNullOrWhiteSpace(updateInfo.Notes))
+        {
+            var notes = MarkdownHelper.StripLeadingVersionHeading(updateInfo.Notes);
+            MarkdownHelper.RenderTo(NotesViewer, notes);
+            NotesPanel.Visibility = Visibility.Visible;
+        }
     }
 
     private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/src/AgentDock/Windows/WhatsNewWindow.xaml
+++ b/src/AgentDock/Windows/WhatsNewWindow.xaml
@@ -1,0 +1,141 @@
+<Window x:Class="AgentDock.Windows.WhatsNewWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mdxaml="clr-namespace:MdXaml;assembly=MdXaml"
+        Title="What's New"
+        Height="560" Width="600"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResizeWithGrip"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Icon="/Assets/agentdock.png"
+        Background="Transparent">
+
+    <Window.Resources>
+        <Style x:Key="DialogButton" TargetType="{x:Type Button}">
+            <Setter Property="MinWidth" Value="76" />
+            <Setter Property="Height" Value="28" />
+            <Setter Property="Padding" Value="12,0" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Background" Value="{DynamicResource HelpCardBackground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource HelpCardBorderBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background"
+                                        Value="{DynamicResource MenuHighlightBackground}" />
+                            </Trigger>
+                            <Trigger Property="IsDefault" Value="True">
+                                <Setter TargetName="Bd" Property="BorderBrush"
+                                        Value="{DynamicResource TabButtonActiveBorderBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="ThemeMarkdownStyle" TargetType="FlowDocument"
+               BasedOn="{StaticResource BaseMarkdownStyle}">
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="FontSize" Value="14" />
+        </Style>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource HelpBackground}"
+            BorderBrush="{DynamicResource ToolbarBorderBrush}"
+            BorderThickness="1"
+            CornerRadius="4">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" /> <!-- Title bar -->
+                <RowDefinition Height="Auto" /> <!-- Heading -->
+                <RowDefinition Height="*" />    <!-- Notes -->
+                <RowDefinition Height="Auto" /> <!-- Buttons -->
+            </Grid.RowDefinitions>
+
+            <!-- Mini title bar -->
+            <Border Grid.Row="0"
+                    Background="{DynamicResource TitleBarBackground}"
+                    CornerRadius="4,4,0,0"
+                    Padding="12,8"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <TextBlock Text="What's New"
+                           FontSize="12"
+                           FontWeight="SemiBold"
+                           Foreground="{DynamicResource TitleBarForeground}" />
+            </Border>
+
+            <!-- Heading -->
+            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="20,18,20,8">
+                <TextBlock Text="&#xEA86;"
+                           FontFamily="Segoe MDL2 Assets"
+                           FontSize="22"
+                           Foreground="{DynamicResource HelpHeadingForeground}"
+                           VerticalAlignment="Center"
+                           Margin="0,0,12,0" />
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock x:Name="HeadingText"
+                               Text="Welcome to Agent Dock"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource HelpHeadingForeground}" />
+                    <TextBlock x:Name="SubheadingText"
+                               Text="Here's what changed in this version."
+                               FontSize="12"
+                               Foreground="{DynamicResource HelpMutedForeground}" />
+                </StackPanel>
+            </StackPanel>
+
+            <!-- Notes -->
+            <Border Grid.Row="2"
+                    Background="{DynamicResource HelpCardBackground}"
+                    BorderBrush="{DynamicResource HelpCardBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="3"
+                    Margin="20,0,20,12">
+                <mdxaml:MarkdownScrollViewer x:Name="NotesViewer"
+                                             Background="Transparent"
+                                             Foreground="{DynamicResource HelpForeground}"
+                                             MarkdownStyle="{StaticResource ThemeMarkdownStyle}"
+                                             VerticalScrollBarVisibility="Auto"
+                                             Padding="16,12,16,12" />
+            </Border>
+
+            <!-- Buttons -->
+            <StackPanel Grid.Row="3"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Margin="20,0,20,16">
+                <TextBlock VerticalAlignment="Center" Margin="0,0,12,0" FontSize="12">
+                    <Hyperlink x:Name="ViewAllLink"
+                               NavigateUri="https://github.com/develorem/agent-dock/releases"
+                               RequestNavigate="Hyperlink_RequestNavigate">
+                        <Run Foreground="{DynamicResource HelpLinkForeground}"
+                             Text="View all releases &#x2197;" />
+                    </Hyperlink>
+                </TextBlock>
+                <Button x:Name="CloseButton"
+                        Content="Close"
+                        Style="{StaticResource DialogButton}"
+                        IsDefault="True"
+                        IsCancel="True"
+                        Click="CloseButton_Click" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/src/AgentDock/Windows/WhatsNewWindow.xaml.cs
+++ b/src/AgentDock/Windows/WhatsNewWindow.xaml.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Navigation;
+using AgentDock.Services;
+
+namespace AgentDock.Windows;
+
+public partial class WhatsNewWindow : Window
+{
+    public WhatsNewWindow(Window owner, string version, string markdown)
+    {
+        InitializeComponent();
+        Owner = owner;
+
+        HeadingText.Text = $"What's new in v{version}";
+        var notes = MarkdownHelper.StripLeadingVersionHeading(markdown);
+        MarkdownHelper.RenderTo(NotesViewer, notes);
+    }
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        => DragMove();
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e)
+        => DialogResult = true;
+
+    private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = e.Uri.AbsoluteUri,
+            UseShellExecute = true
+        });
+        e.Handled = true;
+    }
+}

--- a/src/AgentDock/Windows/WorkspaceSettingsDialog.xaml
+++ b/src/AgentDock/Windows/WorkspaceSettingsDialog.xaml
@@ -1,0 +1,199 @@
+<Window x:Class="AgentDock.Windows.WorkspaceSettingsDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Workspace Settings"
+        Width="640" Height="440"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Icon="/Assets/agentdock.png"
+        Background="Transparent">
+
+    <Window.Resources>
+        <Style x:Key="DialogButton" TargetType="{x:Type Button}">
+            <Setter Property="MinWidth" Value="76" />
+            <Setter Property="Height" Value="28" />
+            <Setter Property="Padding" Value="12,0" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Background" Value="{DynamicResource HelpCardBackground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource HelpCardBorderBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background"
+                                        Value="{DynamicResource MenuHighlightBackground}" />
+                            </Trigger>
+                            <Trigger Property="IsDefault" Value="True">
+                                <Setter TargetName="Bd" Property="BorderBrush"
+                                        Value="{DynamicResource TabButtonActiveBorderBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="NavListItem" TargetType="{x:Type ListBoxItem}">
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Padding" Value="12,8" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                Padding="{TemplateBinding Padding}"
+                                CornerRadius="3"
+                                Margin="0,1">
+                            <ContentPresenter />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background"
+                                        Value="{DynamicResource MenuHighlightBackground}" />
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Bd" Property="Background"
+                                        Value="{DynamicResource ExplorerSelectedBackground}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="SectionHeader" TargetType="{x:Type TextBlock}">
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Margin" Value="0,0,0,12" />
+        </Style>
+
+        <Style x:Key="FieldLabel" TargetType="{x:Type TextBlock}">
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Margin" Value="0,0,0,4" />
+        </Style>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource HelpBackground}"
+            BorderBrush="{DynamicResource ToolbarBorderBrush}"
+            BorderThickness="1"
+            CornerRadius="4">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Border Grid.Row="0"
+                    Background="{DynamicResource TitleBarBackground}"
+                    CornerRadius="4,4,0,0"
+                    Padding="12,8"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <TextBlock Text="Workspace Settings"
+                           FontSize="12"
+                           FontWeight="SemiBold"
+                           Foreground="{DynamicResource TitleBarForeground}" />
+            </Border>
+
+            <Grid Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="160" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <Border Grid.Column="0"
+                        BorderBrush="{DynamicResource ToolbarBorderBrush}"
+                        BorderThickness="0,0,1,0"
+                        Padding="8,8">
+                    <ListBox x:Name="NavList"
+                             Background="Transparent"
+                             BorderThickness="0"
+                             ItemContainerStyle="{StaticResource NavListItem}"
+                             SelectionChanged="NavList_SelectionChanged">
+                        <ListBoxItem Tag="appearance" IsSelected="True">Appearance</ListBoxItem>
+                    </ListBox>
+                </Border>
+
+                <ScrollViewer Grid.Column="1"
+                              VerticalScrollBarVisibility="Auto"
+                              Padding="20,16">
+                    <Grid>
+                        <StackPanel x:Name="AppearanceSection">
+                            <TextBlock Text="Appearance" Style="{StaticResource SectionHeader}" />
+
+                            <TextBlock Text="Theme" Style="{StaticResource FieldLabel}" />
+                            <ComboBox x:Name="ThemeCombo"
+                                      Height="28"
+                                      FontSize="13"
+                                      VerticalContentAlignment="Center"
+                                      Margin="0,0,0,16">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding DisplayName}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+
+                            <TextBlock Text="Toolbar Position" Style="{StaticResource FieldLabel}" />
+                            <ComboBox x:Name="ToolbarPositionCombo"
+                                      Height="28"
+                                      FontSize="13"
+                                      VerticalContentAlignment="Center"
+                                      Margin="0,0,0,16">
+                                <ComboBoxItem Content="Top" Tag="Top" />
+                                <ComboBoxItem Content="Left" Tag="Left" />
+                                <ComboBoxItem Content="Right" Tag="Right" />
+                                <ComboBoxItem Content="Bottom" Tag="Bottom" />
+                            </ComboBox>
+
+                            <TextBlock Text="Workspace settings apply to the currently open workspace. Save the workspace (File → Save Workspace) to keep them across launches."
+                                       FontSize="11"
+                                       Opacity="0.7"
+                                       TextWrapping="Wrap"
+                                       Foreground="{DynamicResource HelpForeground}"
+                                       Margin="0,8,0,0" />
+                        </StackPanel>
+                    </Grid>
+                </ScrollViewer>
+            </Grid>
+
+            <Border Grid.Row="2"
+                    BorderBrush="{DynamicResource ToolbarBorderBrush}"
+                    BorderThickness="0,1,0,0"
+                    Padding="16,12">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Content="OK"
+                            Style="{StaticResource DialogButton}"
+                            IsDefault="True"
+                            Click="OkButton_Click"
+                            Margin="0,0,8,0" />
+                    <Button Content="Cancel"
+                            Style="{StaticResource DialogButton}"
+                            IsCancel="True"
+                            Click="CancelButton_Click" />
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/src/AgentDock/Windows/WorkspaceSettingsDialog.xaml.cs
+++ b/src/AgentDock/Windows/WorkspaceSettingsDialog.xaml.cs
@@ -1,0 +1,70 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using AgentDock.Models;
+using AgentDock.Services;
+
+namespace AgentDock.Windows;
+
+public partial class WorkspaceSettingsDialog : Window
+{
+    public class Result
+    {
+        public string ThemeId { get; set; } = "";
+        public string ToolbarPosition { get; set; } = "Top";
+    }
+
+    public Result? Outcome { get; private set; }
+
+    private WorkspaceSettingsDialog(string currentThemeId, string currentToolbarPosition)
+    {
+        InitializeComponent();
+
+        ThemeCombo.ItemsSource = ThemeRegistry.All;
+        ThemeCombo.SelectedItem =
+            ThemeRegistry.FindById(currentThemeId) ?? ThemeRegistry.Default;
+
+        foreach (ComboBoxItem item in ToolbarPositionCombo.Items)
+        {
+            if ((string)item.Tag == currentToolbarPosition)
+            {
+                ToolbarPositionCombo.SelectedItem = item;
+                break;
+            }
+        }
+        if (ToolbarPositionCombo.SelectedItem == null)
+            ToolbarPositionCombo.SelectedIndex = 0;
+    }
+
+    public static Result? Show(Window owner, string currentThemeId, string currentToolbarPosition)
+    {
+        var dlg = new WorkspaceSettingsDialog(currentThemeId, currentToolbarPosition) { Owner = owner };
+        return dlg.ShowDialog() == true ? dlg.Outcome : null;
+    }
+
+    private void NavList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        // Single section for now — placeholder for when more sections are added.
+    }
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        => DragMove();
+
+    private void OkButton_Click(object sender, RoutedEventArgs e)
+    {
+        var theme = ThemeCombo.SelectedItem as ThemeDescriptor ?? ThemeRegistry.Default;
+        var toolbar = (ToolbarPositionCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "Top";
+
+        Outcome = new Result
+        {
+            ThemeId = theme.Id,
+            ToolbarPosition = toolbar
+        };
+        DialogResult = true;
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+}


### PR DESCRIPTION
## Summary

Release v0.9.0 bundles 10 commits with new features, fixes, and infrastructure improvements. Highlights:

- **Settings redesign** — Workspace Settings and App Settings dialogs replace the old submenu/dialog patchwork
- **Voice dictation** in the chat input via Windows offline speech recognition
- **Clickable file references** in chat that reveal-and-preview the target file
- **Reveal-in-explorer** button on the diff preview
- **Integrated `>` prompt marker** inside the chat input chrome
- **Markdown bold-across-code-spans** rendering fix
- **JSON syntax highlighting** in the file preview pane
- **App version in title bar**
- **Release notes everywhere** — GitHub Releases page, Update dialog, What's New popup on first launch after update, About dialog link
- **Reliable taskbar restore** — fixes long-idle minimize bug via foreground-lock workaround
- **No more token-delta log spam** — streaming deltas no longer hit disk
- **No more empty thinking bubbles** — lazy creation on first real `thinking_delta`
- **Git-status watcher** bumped to 64 KB buffer to survive busy repos
- **Virtualized chat message list** with cached rendered markdown — major perf win on long sessions / tab switches
- **Pre-release channel** — opt-in Beta updates with proper SemVer ordering
- **VS Code-style tabs + optional tab groups** — meta-tab layer for organizing large workspaces (workspace file format bumped to v2, backward compatible)

Full per-feature changelog in `docs/release-notes/v0.9.0.md`.

## Test plan

- [ ] Build and smoke-test on a fresh Windows 11 machine
- [ ] Voice dictation mic button on a Win10 19041+ machine
- [ ] Open an existing v1 workspace file — verify it loads with no groups
- [ ] Create a tab group, rename it, drag a tab into it, delete it
- [ ] Trigger an update from a prior version — verify What's New popup on next launch
- [ ] Switch Release Channel to Beta — verify it picks up a pre-release tag
- [ ] Long chat session (>200 messages) — verify scrolling and tab switches stay snappy