### PR TITLE
v0.9.1: image attachments, send queue, subagent visibility, browser link, markdown/table fixes

### DIFF
--- a/docs/release-notes/v0.9.1.md
+++ b/docs/release-notes/v0.9.1.md
@@ -1,0 +1,60 @@
+# v0.9.1
+
+## Chat: Attach Images to a Message
+
+- You can now send images to Claude alongside your prompt. **Paste** a screenshot or copied image with **Ctrl+V** into the chat input, or **drag and drop** image files onto the input area
+- Queued images appear as **thumbnail chips** above the input box; you can attach several at once. Click a thumbnail to open it **larger in a preview window**, where you can **Remove** it — or use the chip's **✕** for a quick remove
+- A new **Cancel** button (✕) appears next to Send whenever you've typed something or attached an image. Click it to discard the draft and clear all attachments in one go
+- On send, the images travel with your message as native multimodal content (no temp files, no extra tool round-trip) and the sent images show as thumbnails in your message bubble
+- Supports common formats (PNG, JPEG, GIF, BMP, TIFF, WebP). Large images are automatically downscaled to Claude's recommended size, and the upload is normalized to PNG (or JPEG when smaller) so it stays within the API's size limit
+- A message can be sent with images and no text, or text and images together
+
+## Chat: Live Subagent Indicator
+
+- When Claude spawns a **subagent** (or a background task), the chat now shows it. A distinct **◆ Subagent** line appears in the activity bubble naming the subagent type (e.g. *Explore*) and what it was asked to do
+- The status line gains a live running-work suffix next to *Working…*, so you can tell work is still in flight even while a subagent churns away — it clears as each one finishes
+- **Background tasks, subagents, and workflows are now counted separately** in that suffix (e.g. *"2 subagents · 1 background task running"*). Previously a background shell — like one watching a build or a deploy — was lumped in and mislabelled as a "subagent"; the count now reflects what's actually running
+- **A subagent's final report is now captured in the transcript.** When a subagent finishes, its output is surfaced as a distinct **◆ report** block (set apart with an accent border) instead of being discarded — so you can see what the subagent actually found or did, not just that it ran
+- The report is **tagged with the model** the subagent ran on (e.g. *claude-sonnet-5*, *claude-fable-5*), so mixed-model runs (Fable for planning, Opus/Sonnet for execution) are visible at a glance
+- A subagent's **internal** tool calls still don't leak into the main transcript as if the top-level agent had run them; only its final report and the running counts are surfaced
+
+## Chat: Selectable & Copyable Tables
+
+- Text inside rendered markdown tables can now be **highlighted and copied** with the mouse, just like the rest of a reply. Each cell keeps its formatting (bold, code, and clickable links) while remaining selectable
+- Rendered tables also keep a **right-click → Copy table** menu (alongside a plain **Copy** for the current selection). Pasting lands cleanly: **Excel / Google Sheets** split it back into rows and columns (tab-separated), and rich targets like **Word** keep the table grid (HTML)
+
+## Chat: Taller Input Box
+
+- The chat input now starts about **three rows tall** instead of one, so there's room to draft a few lines (and see attached image chips) without it feeling cramped. It still grows as you type and scrolls once it gets large
+
+## Chat: Queue Messages While Claude Is Working
+
+- You can now **line up messages while Claude is busy**. Type a follow-up and press **Enter** (or click **Send**) mid-turn and it's added to a **send queue** instead of being dropped — the input clears so you can immediately queue the next one. Each queued message is sent automatically, **one after another**, as each turn returns
+- A **"Queued to send"** panel appears above the input listing everything waiting, with a live status for each (**Queued**, or a countdown for scheduled items) and a **✕** to remove any entry from the queue
+- **Scheduling is now part of the same queue.** The **clock button** still composes a message to send after a delay — it just drops that message into the queue with a "not before" time rather than locking the input. This means you can keep typing and queueing while a message waits for its scheduled time
+- Messages run in **strict order** (first in, first out). A message scheduled for later holds its place in line: everything queued behind it waits until it fires, then the rest follow. So you can **schedule a message for +1h and queue a follow-up to run right after it returns** — and build up a whole to-do list for the session
+- The queue is **in-memory** for the session: it's cleared if you Stop the session, and it isn't saved across app restarts
+
+## Tabs: Scheduled-Message Indicator
+
+- A session with a **scheduled message** now shows a distinct **clock glyph (◷)** in its tab — in a new cyan/teal accent colour — in place of the usual green "ready" diamond, so you can spot a parked message at a glance
+- **Hovering the tab** shows when the message is due (the scheduled time is appended to the tab's tooltip); it reverts to the plain folder path once the message fires or is cancelled
+- More urgent states still win on the session tab: a tab that's **working**, **waiting for permission**, **errored**, or has an **unseen completion** shows that signal instead of the clock
+- On a **group** tab the clock sits at the **lowest priority** — the flashing-green (new response), orange (question/permission), working, error, and idle states of its sessions all take precedence, so the group only shows the clock when it is otherwise quiet
+
+## Git: Open Repository in Browser
+
+- The git-status panel's branch header now shows a **globe button** when the repo's `origin` remote points at a recognized web host. Click it to open the repository's page in your **default browser**
+- Works for **GitHub, GitLab, Bitbucket, Codeberg** and **Azure DevOps**, over both **https** and **SSH** remotes (`git@…` and `ssh://…`), including self-hosted GitHub Enterprise / GitLab instances. Embedded credentials and a trailing `.git` are stripped from the opened URL
+- The button stays **hidden** when there's no `origin`, or when the remote is a plain SSH/file git server that isn't a web host — so you only see it when there's actually a page to open
+
+## Fixes
+
+- **Markdown:** a line with two bold-then-code constructs (e.g. `**iac-aws**: ` `` `a` `` ` and **gcp**: ` `` `b` ``) no longer renders a stray literal `**` after the first bold. The bold-fixup pass now pairs `**` delimiters left-to-right instead of mistakenly binding one bold's closing `**` to the next bold's opening `**`
+- **Markdown:** a bare URL wrapped in bold (e.g. `**https://resend.com**`) now renders as a proper **bold link** instead of showing the literal asterisks. The auto-linkifier was greedily pulling the closing `**` into the URL; it now stops the URL at the bold delimiter
+- **Markdown:** a **single-line** reply that contains inline markdown — bold, italic, a code span, a link, or a bare URL — now renders formatted and offers the source/rendered toggle. Previously only multi-line replies were treated as markdown, so a one-line answer showed literal `**`/`*` with no formatting and no toggle
+- **Chat:** sending a message no longer **chimes and prints a $0 cost line immediately**. When a session was resumed with a leftover background shell from a previous turn, the CLI emits an empty "flush" result (zero turns, zero cost) *before* actually starting your turn; the app mistook it for turn completion, dropped to idle, played the "waiting for you" chime and logged a $0 cost. That empty result is now recognized and ignored, so the chime and cost line only appear when the turn genuinely finishes
+- **Chat:** the **schedule (clock) button** now works from an **empty input box**. Previously, clicking it with nothing typed silently did nothing — the compose dialog only showed the drafted message as a read-only preview, so scheduling couldn't start from scratch. The dialog's message field is now **editable**: click the clock any time to open it, type (or edit) the message, pick a delay, and schedule. When there's no draft it focuses the message field; when there is one it jumps straight to the delay
+- **Chat:** **web links in a reply are now clickable** and open in your default browser. They rendered as links but swallowed every click, because the markdown renderer wires links through a command that has no handler in our chat view — which silently *disables* the link. Links now navigate on click (this also covers `mailto:` links and the click-to-reveal for file-path references)
+- **Markdown:** table text is now **readable in dark themes**. Rendered tables are drawn with selectable cells, and each cell's text was picking up the default (near-black) control colour instead of the theme's — so headings and contents were invisible on a dark background. Cell text now uses the active theme's foreground, matching the rest of the reply
+- **Images:** **pasting a screenshot** now works. Snipping a region and pressing **Ctrl+V** in the chat previously did nothing, because a text box ignores Ctrl+V when the clipboard holds only an image (no text). Ctrl+V is now intercepted directly, so an image-only clipboard attaches the picture as expected. Pasted screenshots also keep their transparency (the PNG on the clipboard is preferred over the older bitmap format, which could paste with a black background)

--- a/src/AgentDock/Controls/AiChatControl.xaml
+++ b/src/AgentDock/Controls/AiChatControl.xaml
@@ -9,6 +9,7 @@
              mc:Ignorable="d"
              Background="{DynamicResource ChatBackground}">
     <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <Style x:Key="ChatButtonStyle" TargetType="Button">
             <Setter Property="FontFamily" Value="Cascadia Code, Consolas, Courier New" />
             <Setter Property="FontSize" Value="11" />
@@ -18,6 +19,12 @@
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="Cursor" Value="Hand" />
             <Setter Property="Padding" Value="8,4" />
+            <Style.Triggers>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter Property="Opacity" Value="0.35" />
+                    <Setter Property="Cursor" Value="Arrow" />
+                </Trigger>
+            </Style.Triggers>
         </Style>
         <Style x:Key="ChatMarkdownStyle" TargetType="FlowDocument"
                BasedOn="{StaticResource BaseMarkdownStyle}">
@@ -70,6 +77,47 @@
             </StackPanel>
         </DataTemplate>
 
+        <!-- A subagent / background-task spawn line inside the activity bubble. Rendered
+             with a diamond glyph and the working-accent colour so it stands apart from
+             the main agent's own (green) tool calls. -->
+        <DataTemplate DataType="{x:Type models:SubagentEntry}">
+            <StackPanel Margin="0,0,0,6">
+                <TextBlock FontFamily="Cascadia Code, Consolas, Courier New"
+                           FontSize="10"
+                           Foreground="{DynamicResource ChatStatusWorkingForeground}">
+                    <Run Text="◆ Subagent:" FontWeight="Bold" />
+                    <Run Text="{Binding Label, Mode=OneTime}" />
+                </TextBlock>
+                <TextBox Text="{Binding Description, Mode=OneTime}"
+                         Style="{StaticResource ChatSelectableText}"
+                         FontSize="10"
+                         Foreground="{DynamicResource ChatStatusWorkingForeground}"
+                         Margin="0,2,0,0" />
+            </StackPanel>
+        </DataTemplate>
+
+        <!-- A completed subagent's final report inside the activity bubble. Set apart with
+             a diamond header (subagent type + model tag) and an accent left-border so the
+             subagent's actual output reads distinctly from the main agent's content. -->
+        <DataTemplate DataType="{x:Type models:SubagentReportEntry}">
+            <Border BorderBrush="{DynamicResource ChatStatusWorkingForeground}"
+                    BorderThickness="2,0,0,0"
+                    Padding="8,2,0,0"
+                    Margin="0,2,0,8">
+                <StackPanel>
+                    <TextBlock Text="{Binding Header, Mode=OneTime}"
+                               FontFamily="Cascadia Code, Consolas, Courier New"
+                               FontSize="10"
+                               FontWeight="Bold"
+                               Foreground="{DynamicResource ChatStatusWorkingForeground}" />
+                    <TextBox Text="{Binding Text, Mode=OneTime}"
+                             Style="{StaticResource ChatSelectableText}"
+                             FontSize="11"
+                             Margin="0,3,0,0" />
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
         <!-- A gray thinking/commentary block inside the activity bubble. Streams live. -->
         <DataTemplate DataType="{x:Type models:ActivityThinkingEntry}">
             <TextBox Text="{Binding Text, Mode=OneWay}"
@@ -102,6 +150,52 @@
                                          Padding="0"
                                          DataContextChanged="AssistantMarkdown_DataContextChanged"
                                          Loaded="AssistantMarkdown_Loaded" />
+        </DataTemplate>
+
+        <!-- A pending-image chip shown in the input area before send: thumbnail,
+             name, and a remove (✕) button. -->
+        <DataTemplate DataType="{x:Type models:PendingImageAttachment}">
+            <Border Background="{DynamicResource ChatInputBackground}"
+                    BorderBrush="{DynamicResource ChatInputBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Margin="0,0,4,4"
+                    Padding="3">
+                <StackPanel Orientation="Horizontal">
+                    <Button Click="PreviewAttachment_Click"
+                            Tag="{Binding}"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Padding="0"
+                            Cursor="Hand"
+                            ToolTip="Click to view larger">
+                        <Image Source="{Binding Thumbnail}"
+                               Width="32" Height="32"
+                               Stretch="UniformToFill"
+                               SnapsToDevicePixels="True" />
+                    </Button>
+                    <TextBlock Text="{Binding DisplayName}"
+                               FontFamily="Cascadia Code, Consolas, Courier New"
+                               FontSize="10"
+                               Foreground="{DynamicResource ChatMutedForeground}"
+                               VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"
+                               MaxWidth="120"
+                               Margin="6,0,4,0" />
+                    <Button Click="RemoveAttachment_Click"
+                            Tag="{Binding}"
+                            Content="&#x2715;"
+                            FontFamily="Cascadia Code, Consolas, Courier New"
+                            FontSize="10"
+                            Foreground="{DynamicResource ChatDangerForeground}"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Cursor="Hand"
+                            Padding="4,0"
+                            VerticalAlignment="Center"
+                            ToolTip="Remove this image" />
+                </StackPanel>
+            </Border>
         </DataTemplate>
     </UserControl.Resources>
     <Grid>
@@ -324,7 +418,75 @@
                     Background="{DynamicResource ChatStatusBarBackground}"
                     BorderBrush="{DynamicResource ChatInputBorderBrush}"
                     BorderThickness="0,1,0,0"
-                    Padding="8,6">
+                    Padding="8,6"
+                    AllowDrop="True"
+                    PreviewDragOver="InputPanel_PreviewDragOver"
+                    PreviewDrop="InputPanel_PreviewDrop">
+                <StackPanel>
+                <!-- Send queue (hidden when empty): messages waiting to run after the
+                     current turn, plus any time-scheduled messages. Strict FIFO. -->
+                <Border x:Name="QueueBar"
+                        Visibility="Collapsed"
+                        Margin="0,0,0,6"
+                        Background="{DynamicResource ChatThinkingBackground}"
+                        BorderBrush="{DynamicResource ChatThinkingBorderBrush}"
+                        BorderThickness="1"
+                        CornerRadius="4"
+                        Padding="6,4">
+                    <StackPanel>
+                        <TextBlock Text="Queued to send"
+                                   FontFamily="Cascadia Code, Consolas, Courier New"
+                                   FontSize="10"
+                                   Foreground="{DynamicResource ChatMutedForeground}"
+                                   Margin="0,0,0,3" />
+                        <ItemsControl x:Name="QueueList"
+                                      ItemsSource="{Binding QueuedMessages, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type models:QueuedMessage}">
+                                    <DockPanel Margin="0,1">
+                                        <Button DockPanel.Dock="Right"
+                                                Click="RemoveQueued_Click"
+                                                Tag="{Binding Id}"
+                                                Content="&#x2715;"
+                                                FontFamily="Cascadia Code, Consolas, Courier New"
+                                                FontSize="10"
+                                                Foreground="{DynamicResource ChatDangerForeground}"
+                                                Background="Transparent"
+                                                BorderThickness="0"
+                                                Cursor="Hand"
+                                                Padding="4,0"
+                                                VerticalAlignment="Center"
+                                                ToolTip="Remove from the queue" />
+                                        <TextBlock DockPanel.Dock="Right"
+                                                   Text="{Binding StatusText}"
+                                                   FontFamily="Cascadia Code, Consolas, Courier New"
+                                                   FontSize="10"
+                                                   Foreground="{DynamicResource ChatSubtleForeground}"
+                                                   VerticalAlignment="Center"
+                                                   Margin="8,0,4,0" />
+                                        <TextBlock Text="{Binding Preview}"
+                                                   FontFamily="Cascadia Code, Consolas, Courier New"
+                                                   FontSize="11"
+                                                   Foreground="{DynamicResource ChatTextForeground}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   VerticalAlignment="Center" />
+                                    </DockPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </Border>
+                <!-- Pending image attachments (hidden when none) -->
+                <ItemsControl x:Name="AttachmentsBar"
+                              Visibility="Collapsed"
+                              Margin="0,0,0,4"
+                              ItemsSource="{Binding PendingAttachments, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
                 <DockPanel>
                     <Button x:Name="SendButton"
                             Content="Send"
@@ -333,7 +495,8 @@
                             VerticalAlignment="Bottom"
                             Style="{StaticResource ChatButtonStyle}"
                             Width="60" Height="28"
-                            Margin="6,0,0,0" />
+                            Margin="6,0,0,0"
+                            ToolTip="Send now, or — while Claude is working — queue to run after the current task (Enter)" />
                     <Button x:Name="ScheduleButton"
                             Click="ScheduleButton_Click"
                             DockPanel.Dock="Right"
@@ -346,6 +509,20 @@
                                    Text="&#xE823;"
                                    FontFamily="Segoe MDL2 Assets"
                                    FontSize="14" />
+                    </Button>
+                    <Button x:Name="CancelButton"
+                            Click="CancelButton_Click"
+                            DockPanel.Dock="Right"
+                            VerticalAlignment="Bottom"
+                            IsEnabled="False"
+                            Style="{StaticResource ChatButtonStyle}"
+                            Width="32" Height="28"
+                            Margin="6,0,0,0"
+                            ToolTip="Clear the message and remove any attachments">
+                        <TextBlock Text="&#xE74D;"
+                                   FontFamily="Segoe MDL2 Assets"
+                                   FontSize="14"
+                                   Foreground="{DynamicResource ChatDangerForeground}" />
                     </Button>
                     <Popup x:Name="SlashCommandPopup"
                            PlacementTarget="{Binding ElementName=InputBox}"
@@ -437,8 +614,8 @@
                                      AcceptsReturn="True"
                                      TextWrapping="Wrap"
                                      VerticalScrollBarVisibility="Auto"
-                                     MaxHeight="76"
-                                     MinHeight="20"
+                                     MaxHeight="120"
+                                     MinHeight="52"
                                      KeyDown="InputBox_KeyDown"
                                      PreviewKeyDown="InputBox_PreviewKeyDown"
                                      TextChanged="InputBox_TextChanged"
@@ -446,6 +623,7 @@
                         </DockPanel>
                     </Border>
                 </DockPanel>
+                </StackPanel>
             </Border>
 
             <!-- Message list — virtualized. Past messages are immutable record-ish
@@ -493,10 +671,32 @@
                                            FontSize="10"
                                            Foreground="{DynamicResource ChatUserLabelForeground}"
                                            Margin="0,0,0,2" />
+                                <ItemsControl ItemsSource="{Binding Images}"
+                                              Visibility="{Binding HasImages, Converter={StaticResource BoolToVis}}"
+                                              Margin="0,0,0,4">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <WrapPanel />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border CornerRadius="4" Margin="0,0,4,4"
+                                                    BorderBrush="{DynamicResource ChatInputBorderBrush}"
+                                                    BorderThickness="1">
+                                                <Image Source="{Binding}"
+                                                       MaxWidth="180" MaxHeight="180"
+                                                       Stretch="Uniform"
+                                                       SnapsToDevicePixels="True" />
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
                                 <TextBox Text="{Binding Text, Mode=OneTime}"
                                          Style="{StaticResource ChatSelectableText}"
                                          FontSize="12"
-                                         Foreground="{DynamicResource ChatTextForeground}" />
+                                         Foreground="{DynamicResource ChatTextForeground}"
+                                         Visibility="{Binding HasText, Converter={StaticResource BoolToVis}}" />
                             </StackPanel>
                         </Border>
                     </DataTemplate>

--- a/src/AgentDock/Controls/AiChatControl.xaml.cs
+++ b/src/AgentDock/Controls/AiChatControl.xaml.cs
@@ -29,6 +29,10 @@ public partial class AiChatControl : UserControl
     // VirtualizingStackPanel are realized only when scrolled into view.
     public ObservableCollection<ChatMessageVm> Messages { get; } = [];
 
+    // Images queued in the input area, shown as chips and attached to the next
+    // sent message. Bound by AttachmentsBar (RelativeSource to this UserControl).
+    public ObservableCollection<PendingImageAttachment> PendingAttachments { get; } = [];
+
     // Live-tail references — set when the corresponding VM is in the
     // collection, nulled on finalize / removal.
     //
@@ -60,19 +64,39 @@ public partial class AiChatControl : UserControl
     private int _spinnerIndex;
     private static readonly string[] SpinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
+    // In-flight background work the session reports as running, split by kind. Shown as a
+    // suffix on the "Working..." status so the user can tell what kind of work is still in
+    // flight (e.g. a subagent churning) even after the main agent's text has returned.
+    private int _activeSubagents;
+    private int _activeBackgroundTasks;
+    private int _activeWorkflows;
+
     // Pending AskUserQuestion — tracks question text for response.
     private string? _pendingQuestionText;
 
-    // --- Scheduled message ---
-    // When the user schedules a message, its text is parked here and a per-second
-    // timer counts down to _scheduleFireTimeUtc. While a message is scheduled the
-    // input is disabled (the message is "owned" by the schedule) but the clock
-    // button stays live so the user can view the countdown or cancel. At fire time
-    // the message is dispatched as soon as the session is idle.
-    private DispatcherTimer? _scheduleTimer;
-    private string? _scheduledMessageText;
-    private DateTime _scheduleFireTimeUtc;
-    private bool IsScheduled => _scheduledMessageText != null;
+    // --- Send queue (the outbox) ---
+    // A message typed while the session is busy is appended here instead of being
+    // dropped, then dispatched in strict FIFO order as each turn returns. A message
+    // "scheduled" via the clock is the same thing with a NotBeforeUtc time gate. The
+    // pump (PumpQueue) runs whenever the session goes idle and on a per-second timer
+    // (only while the queue is non-empty) that also drives the live countdown labels.
+    // In-memory only — the queue is cleared on Stop and not persisted across restarts.
+    private readonly SendQueue _queue = new();
+    private DispatcherTimer? _queueTimer;
+
+    /// <summary>The queued messages, exposed for the queue panel's ItemsControl binding.</summary>
+    public ObservableCollection<QueuedMessage> QueuedMessages => _queue.Items;
+
+    /// <summary>
+    /// UTC time the next scheduled (time-gated) message will fire, or null when nothing
+    /// is scheduled. Surfaced so the tab strip can show a scheduled-message indicator +
+    /// tooltip. Plain queued messages drain the moment the session is idle, so a
+    /// scheduled item is the only kind that lingers at idle.
+    /// </summary>
+    public DateTime? ScheduledFireTimeUtc => _queue.NextScheduledFireUtc;
+
+    /// <summary>Raised when the send queue changes (message queued/scheduled, sent, or cancelled).</summary>
+    public event Action? ScheduleChanged;
 
     // Last user message timestamp, for the inactivity warning's elapsed text.
     private DateTime _lastMessageSentTime;
@@ -139,6 +163,11 @@ public partial class AiChatControl : UserControl
         InitializeComponent();
         MessageList.ItemsSource = Messages;
         Messages.CollectionChanged += OnMessagesChanged;
+        PendingAttachments.CollectionChanged += (_, _) => UpdateAttachmentsBar();
+        _queue.Changed += OnQueueChanged;
+        // Intercept Ctrl+V so a pasted screenshot / image file becomes an
+        // attachment instead of pasting its path (or nothing) as text.
+        DataObject.AddPastingHandler(InputBox, InputBox_Pasting);
         Log.Info("AiChatControl: InitializeComponent complete");
 
         // Older Win10 builds don't ship the WinRT dictation recognizer — hide the
@@ -173,8 +202,8 @@ public partial class AiChatControl : UserControl
 
     public void Shutdown()
     {
-        _scheduleTimer?.Stop();
-        _scheduleTimer = null;
+        StopQueueTimer();
+        _queue.Clear();
         _session?.Dispose();
         _session = null;
         _processor = null;
@@ -325,6 +354,14 @@ public partial class AiChatControl : UserControl
             case FinalizeThinkingOp: _activityVm?.CloseThinking(); break;
             case EnsureExecutionOp: EnsureActivityVm(); _activityVm!.CloseThinking(); break;
             case AddToolOp t: EnsureActivityVm(); _activityVm!.AddTool(t.Name, t.FormattedInput); break;
+            case AddSubagentOp s: EnsureActivityVm(); _activityVm!.AddSubagent(s.Label, s.Description); break;
+            case AddSubagentReportOp r: EnsureActivityVm(); _activityVm!.AddSubagentReport(r.Label, r.Model, r.Text); break;
+            case ActivityCountsOp ac:
+                _activeSubagents = ac.Subagents;
+                _activeBackgroundTasks = ac.BackgroundTasks;
+                _activeWorkflows = ac.Workflows;
+                RefreshWorkingStatus();
+                break;
             case FinalizeExecutionOp: break; // no-op — see TurnComplete
             case PostAnswerOp p: ApplyPostAnswer(p.Text); break;
             case TurnCompleteOp tc: ApplyTurnComplete(tc.Result); break;
@@ -357,9 +394,12 @@ public partial class AiChatControl : UserControl
     {
         RemoveWaitingBubble();
 
-        var hasNl = text.Contains('\n');
+        // Not just multi-line: a single-line reply can still carry inline markdown
+        // (**bold**, *italic*, `code`, links, bare URLs) that must be rendered — and
+        // that needs the source/rendered toggle — rather than shown with literal stars.
+        var isMarkdown = MarkdownHelper.LooksLikeMarkdown(text);
         Func<FlowDocument>? markdownBuilder = null;
-        if (hasNl)
+        if (isMarkdown)
         {
             var style = (System.Windows.Style)FindResource("ChatMarkdownStyle");
             var projectPath = _projectPath;
@@ -371,8 +411,8 @@ public partial class AiChatControl : UserControl
         Messages.Add(new AssistantMessage(
             id: Guid.NewGuid(),
             text: text,
-            isMarkdownView: hasNl,
-            hasMarkdownToggle: hasNl,
+            isMarkdownView: isMarkdown,
+            hasMarkdownToggle: isMarkdown,
             markdownBuilder: markdownBuilder));
     }
 
@@ -423,6 +463,16 @@ public partial class AiChatControl : UserControl
         }
         else
         {
+            // The turn is over (or paused for a permission prompt). Clear the running
+            // counts except while waiting on a permission, where the subagent that
+            // triggered the prompt is still alive and resumes when granted.
+            if (state != ClaudeSessionState.WaitingForPermission)
+            {
+                _activeSubagents = 0;
+                _activeBackgroundTasks = 0;
+                _activeWorkflows = 0;
+            }
+
             StatusText.Text = state switch
             {
                 ClaudeSessionState.Initializing => "Initializing...",
@@ -447,20 +497,18 @@ public partial class AiChatControl : UserControl
             && state != ClaudeSessionState.Exited;
         DangerIcon.Visibility = showDanger ? Visibility.Visible : Visibility.Collapsed;
 
-        var canSend = state == ClaudeSessionState.Idle;
         // Keep the input box and mic usable while a turn is running so the user can
-        // draft follow-up notes; only the Send button is gated on Idle.
-        // SendCurrentMessage re-checks the session state, so an Enter press can't
-        // actually dispatch a message mid-turn.
+        // draft follow-ups; the Send button stays enabled too, but now enqueues rather
+        // than dispatching when the session is busy (see SendCurrentMessage).
         UpdateSendButtonEnabled();
 
-        if (canSend && !IsScheduled)
+        if (state == ClaudeSessionState.Idle)
+        {
             FocusInput();
-
-        // If a scheduled message is past its fire time and we've just become idle,
-        // send it now.
-        if (canSend)
-            MaybeDispatchSchedule();
+            // The turn returned — dispatch the next queued/scheduled message if one is
+            // ready. The per-second queue timer is a backstop; this makes it immediate.
+            PumpQueue();
+        }
 
         SessionStateChanged?.Invoke(state);
     }
@@ -468,14 +516,44 @@ public partial class AiChatControl : UserControl
     private void StartWorkingAnimation()
     {
         _spinnerIndex = 0;
-        StatusText.Text = $"{SpinnerFrames[0]} Working...";
+        StatusText.Text = WorkingStatusText();
         _workingTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(80) };
         _workingTimer.Tick += (_, _) =>
         {
             _spinnerIndex = (_spinnerIndex + 1) % SpinnerFrames.Length;
-            StatusText.Text = $"{SpinnerFrames[_spinnerIndex]} Working...";
+            StatusText.Text = WorkingStatusText();
         };
         _workingTimer.Start();
+    }
+
+    // "⠹ Working..." plus a "· N subagents · M background tasks running" suffix when the
+    // session reports in-flight work, split by kind so real subagents aren't conflated with
+    // background shells. Built from the current spinner frame and the live counts so both
+    // the 80 ms animation tick and a count change render it.
+    private string WorkingStatusText()
+    {
+        var text = $"{SpinnerFrames[_spinnerIndex]} Working...";
+
+        var parts = new List<string>(3);
+        if (_activeSubagents > 0)
+            parts.Add($"{_activeSubagents} subagent{(_activeSubagents == 1 ? "" : "s")}");
+        if (_activeBackgroundTasks > 0)
+            parts.Add($"{_activeBackgroundTasks} background task{(_activeBackgroundTasks == 1 ? "" : "s")}");
+        if (_activeWorkflows > 0)
+            parts.Add($"{_activeWorkflows} workflow{(_activeWorkflows == 1 ? "" : "s")}");
+
+        if (parts.Count > 0)
+            text += $"  ·  {string.Join(" · ", parts)} running";
+
+        return text;
+    }
+
+    // Refresh the status line in place after the running count changes (the animation
+    // timer also picks it up on its next tick; this makes the update immediate).
+    private void RefreshWorkingStatus()
+    {
+        if (_session?.State == ClaudeSessionState.Working)
+            StatusText.Text = WorkingStatusText();
     }
 
     private void StopWorkingAnimation()
@@ -508,7 +586,7 @@ public partial class AiChatControl : UserControl
         RemoveWaitingBubble();
         RemoveInactivityWarning();
         FinalizeActivity(null);
-        EndSchedule(restoreDraft: null);
+        _queue.Clear();
 
         var session = _session;
         _session = null;
@@ -539,6 +617,7 @@ public partial class AiChatControl : UserControl
     private void InputBox_TextChanged(object sender, TextChangedEventArgs e)
     {
         var text = InputBox.Text;
+        UpdateComposerButtons();
 
         if (!text.StartsWith('/') || text.Any(char.IsWhiteSpace))
         {
@@ -560,6 +639,22 @@ public partial class AiChatControl : UserControl
 
     private void InputBox_PreviewKeyDown(object sender, KeyEventArgs e)
     {
+        // Intercept Ctrl+V for images before the TextBox's Paste command gets a
+        // chance. A plain TextBox disables its Paste command whenever the clipboard
+        // holds no text-compatible format, so an image-only clipboard (e.g. a
+        // Snipping Tool screenshot) would otherwise do nothing — and the
+        // DataObject.Pasting handler below never fires. Reading the clipboard here
+        // sidesteps that gate. Falls through to the normal text paste when there's
+        // no image.
+        if (e.Key == Key.V && Keyboard.Modifiers == ModifierKeys.Control)
+        {
+            if (TryAttachClipboardImages())
+            {
+                e.Handled = true;
+                return;
+            }
+        }
+
         if (!SlashCommandPopup.IsOpen)
             return;
 
@@ -662,148 +757,179 @@ public partial class AiChatControl : UserControl
     private void SendCurrentMessage()
     {
         var text = InputBox.Text.Trim();
-        if (string.IsNullOrEmpty(text))
+        var hasImages = PendingAttachments.Count > 0;
+        if (string.IsNullOrEmpty(text) && !hasImages)
             return;
 
-        // Local commands are handled regardless of session state; consume the input.
-        if (text.StartsWith('/') && TryHandleLocalCommand(text))
+        // Local commands are handled regardless of session state and are never queued;
+        // consume the input. Images force a real send — a slash command can't carry them.
+        if (!hasImages && text.StartsWith('/') && TryHandleLocalCommand(text))
         {
             InputBox.Text = "";
             return;
         }
 
-        // Can't dispatch to Claude unless the session is idle. The input box stays
-        // enabled mid-turn so the user can draft notes — leave their text in place
-        // rather than clearing it on an Enter that can't send yet.
-        if (_session == null || _session.State != ClaudeSessionState.Idle)
+        // A live session is required to send or queue.
+        if (_session == null)
             return;
 
+        // Snapshot the queued images for both the payload and the bubble, then clear
+        // the input area — the message now belongs to the send path (immediate or queued).
+        var attachments = PendingAttachments.Select(a => a.ToAttachment()).ToList();
+        var thumbnails = hasImages
+            ? PendingAttachments.Select(a => a.Thumbnail).ToList()
+            : null;
+        PendingAttachments.Clear();
         InputBox.Text = "";
 
-        // Defensive turn-boundary finalize — should already have happened on
-        // the previous result, but covers edge cases (manual /compact mid-stream etc.).
+        // Dispatch immediately only when the session is idle AND nothing is already
+        // queued ahead of this — otherwise append so strict FIFO order is preserved
+        // (a new message can't jump the queue, and a busy session no longer drops it).
+        if (_session.State == ClaudeSessionState.Idle && _queue.IsEmpty)
+            Dispatch(text, attachments, thumbnails);
+        else
+            _queue.Enqueue(new QueuedMessage
+            {
+                Text = text,
+                Attachments = attachments,
+                Thumbnails = thumbnails,
+            });
+
+        FocusInput();
+    }
+
+    // The actual send: finalize the previous turn's activity bubble, echo the user
+    // message, show the waiting placeholder, and hand the text + images to the session.
+    // Shared by the immediate-send path and the queue pump so both behave identically.
+    private void Dispatch(string text, IReadOnlyList<ImageAttachment> attachments, IReadOnlyList<ImageSource>? thumbnails)
+    {
+        // Defensive turn-boundary finalize — should already have happened on the
+        // previous result, but covers edge cases (manual /compact mid-stream etc.).
         FinalizeActivity(null);
         _processor?.Reset();
 
         _lastMessageSentTime = DateTime.UtcNow;
-        AddUserMessage(text);
+        AddUserMessage(text, thumbnails);
         ShowWaitingBubble();
-        _session.SendMessage(text);
+        _session!.SendMessage(text, attachments);
     }
 
-    // --- Scheduled Messages ---
+    // --- Send Queue (the outbox) ---
 
-    // Keeps the Send button disabled both mid-turn and whenever a message is
-    // scheduled (the input is "locked" by the pending send).
+    // The Send button is enabled whenever the session can take work — idle (dispatch
+    // now) or working (append to the queue). It's disabled only when there's no live
+    // session or it has exited.
     private void UpdateSendButtonEnabled()
-        => SendButton.IsEnabled = _session?.State == ClaudeSessionState.Idle && !IsScheduled;
+        => SendButton.IsEnabled = _session?.State is ClaudeSessionState.Idle or ClaudeSessionState.Working;
 
-    // Clock button. With no message scheduled it opens the compose dialog for the
-    // current draft; while one is scheduled it opens the manage dialog (countdown +
-    // cancel), which stays clickable even though the input is disabled.
+    // Clock button: always opens the compose dialog to add a time-scheduled message to
+    // the queue. Cancelling / viewing pending items is done inline in the queue panel,
+    // so there's no separate manage dialog anymore.
     private void ScheduleButton_Click(object sender, RoutedEventArgs e)
     {
+        if (_session == null) return;
+
         var owner = Window.GetWindow(this)!;
+        // Seed the dialog with whatever's drafted — including nothing. The message is
+        // editable there, so scheduling can start from an empty input box.
+        var result = ScheduleMessageDialog.ShowCompose(owner, InputBox.Text.Trim());
+        if (!result.HasValue) return;
 
-        if (IsScheduled)
-        {
-            if (ScheduleMessageDialog.ShowManage(owner, _scheduledMessageText!, _scheduleFireTimeUtc))
-                CancelSchedule();
-            return;
-        }
-
-        // Local commands are handled immediately, never sent to Claude, so there's
-        // nothing to schedule. Keep the clock for real prompts only.
-        var text = InputBox.Text.Trim();
-        if (string.IsNullOrEmpty(text))
-        {
-            FocusInput();
-            return;
-        }
-
-        var delay = ScheduleMessageDialog.ShowCompose(owner, text);
-        if (delay.HasValue)
-            BeginSchedule(text, delay.Value);
-    }
-
-    private void BeginSchedule(string text, TimeSpan delay)
-    {
-        _scheduledMessageText = text;
-        _scheduleFireTimeUtc = DateTime.UtcNow + delay;
-
-        // The message is now owned by the schedule — clear the draft and lock input.
+        // The draft (and any attachments it was composed alongside) now belongs to the
+        // scheduled message — consume them so they aren't also sent from the input box.
+        var attachments = PendingAttachments.Select(a => a.ToAttachment()).ToList();
+        var thumbnails = PendingAttachments.Count > 0
+            ? PendingAttachments.Select(a => a.Thumbnail).ToList()
+            : null;
+        PendingAttachments.Clear();
         InputBox.Text = "";
-        InputBorder.IsEnabled = false;
-        UpdateSendButtonEnabled();
-        UpdateScheduleButtonVisual();
 
-        _scheduleTimer = new DispatcherTimer(DispatcherPriority.Background)
+        _queue.Enqueue(new QueuedMessage
         {
-            Interval = TimeSpan.FromSeconds(1)
-        };
-        _scheduleTimer.Tick += (_, _) => MaybeDispatchSchedule();
-        _scheduleTimer.Start();
-
-        AddSystemMessage($"Message scheduled for {_scheduleFireTimeUtc.ToLocalTime():t}.");
-    }
-
-    // Fires the scheduled message once its time has come and the session is idle.
-    // The per-second timer keeps retrying if the session is busy at fire time;
-    // OnStateChanged also calls this the moment we return to Idle.
-    private void MaybeDispatchSchedule()
-    {
-        if (!IsScheduled) return;
-        if (DateTime.UtcNow < _scheduleFireTimeUtc) return;
-        if (_session == null || _session.State != ClaudeSessionState.Idle) return;
-
-        var text = _scheduledMessageText!;
-        EndSchedule(restoreDraft: null);
-
-        // Route through the normal send path so a scheduled slash command (e.g.
-        // /compact) or prompt behaves exactly like one typed by hand.
-        InputBox.Text = text;
-        SendCurrentMessage();
-    }
-
-    // User cancelled a pending send — return the message to the draft box so it can
-    // be edited or sent normally.
-    private void CancelSchedule()
-    {
-        var text = _scheduledMessageText;
-        EndSchedule(restoreDraft: text);
-        AddSystemMessage("Scheduled message cancelled.");
+            Text = result.Value.message,
+            Attachments = attachments,
+            Thumbnails = thumbnails,
+            NotBeforeUtc = DateTime.UtcNow + result.Value.delay,
+        });
         FocusInput();
     }
 
-    // Tears down the schedule (timer + state) and unlocks the input. When
-    // <paramref name="restoreDraft"/> is non-null its text is put back in the box.
-    private void EndSchedule(string? restoreDraft)
+    // Remove (✕) button on a queue-panel row.
+    private void RemoveQueued_Click(object sender, RoutedEventArgs e)
     {
-        _scheduleTimer?.Stop();
-        _scheduleTimer = null;
-        _scheduledMessageText = null;
-
-        InputBorder.IsEnabled = true;
-        if (restoreDraft != null)
-            InputBox.Text = restoreDraft;
-        UpdateSendButtonEnabled();
-        UpdateScheduleButtonVisual();
+        if (sender is FrameworkElement { Tag: Guid id })
+            _queue.Remove(id);
     }
 
-    // Tints the clock glyph while a message is scheduled so the locked state reads
-    // at a glance, and points the tooltip at the manage dialog.
+    // Runs whenever the queue's contents change: toggle the panel, (re)start or stop
+    // the per-second timer, refresh the countdown labels + clock tint, and notify the
+    // tab strip.
+    private void OnQueueChanged()
+    {
+        QueueBar.Visibility = _queue.IsEmpty ? Visibility.Collapsed : Visibility.Visible;
+
+        if (_queue.IsEmpty)
+            StopQueueTimer();
+        else
+            EnsureQueueTimer();
+
+        RefreshQueueStatuses();
+        UpdateScheduleButtonVisual();
+        ScheduleChanged?.Invoke();
+    }
+
+    private void EnsureQueueTimer()
+    {
+        if (_queueTimer != null) return;
+        _queueTimer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromSeconds(1)
+        };
+        _queueTimer.Tick += (_, _) =>
+        {
+            RefreshQueueStatuses();
+            PumpQueue();
+        };
+        _queueTimer.Start();
+    }
+
+    private void StopQueueTimer()
+    {
+        _queueTimer?.Stop();
+        _queueTimer = null;
+    }
+
+    private void RefreshQueueStatuses()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var message in _queue.Items)
+            message.RefreshStatus(now);
+    }
+
+    // Dispatches the head of the queue if it's ready and the session is idle. Called on
+    // return-to-idle (OnStateChanged) and on each queue-timer tick. Sends exactly one
+    // message — SendMessage flips the session to Working synchronously, so a re-entrant
+    // pump before the next idle can't double-send.
+    private void PumpQueue()
+    {
+        if (_session == null || _session.State != ClaudeSessionState.Idle) return;
+
+        var head = _queue.PeekReady(DateTime.UtcNow);
+        if (head == null) return;
+
+        _queue.DequeueHead();
+        Dispatch(head.Text, head.Attachments, head.Thumbnails);
+    }
+
+    // Tints the clock glyph while a scheduled (time-gated) message is pending so the
+    // waiting state reads at a glance.
     private void UpdateScheduleButtonVisual()
     {
-        if (IsScheduled)
-        {
-            ScheduleIcon.Foreground = ThemeManager.GetBrush("ChatStatusWarningForeground");
-            ScheduleButton.ToolTip = "Message scheduled — click to view the countdown or cancel";
-        }
-        else
-        {
-            ScheduleIcon.Foreground = ThemeManager.GetBrush("ChatButtonForeground");
-            ScheduleButton.ToolTip = "Schedule this message to send later";
-        }
+        var hasScheduled = _queue.NextScheduledFireUtc != null;
+        ScheduleIcon.Foreground = hasScheduled
+            ? ThemeManager.GetBrush("ChatStatusWarningForeground")
+            : ThemeManager.GetBrush("ChatButtonForeground");
+        ScheduleButton.ToolTip = "Schedule a message to send later";
     }
 
     /// <summary>
@@ -868,14 +994,143 @@ public partial class AiChatControl : UserControl
         }
     }
 
+    // --- Image Attachments ---
+
+    // The command-driven paste path (e.g. the right-click "Paste" menu item, or a
+    // Ctrl+V that carried text alongside an image). Ctrl+V for an image-only
+    // clipboard is handled earlier in InputBox_PreviewKeyDown — the Paste command
+    // never executes without a text format, so this handler wouldn't fire for it.
+    private void InputBox_Pasting(object sender, DataObjectPastingEventArgs e)
+    {
+        if (TryAttachClipboardImages())
+            e.CancelCommand();
+    }
+
+    // Reads the system clipboard for image file(s) or a raw/screenshot bitmap and,
+    // if found, queues them as attachments. Returns true when at least one image was
+    // attached, so the caller can suppress the default text paste.
+    private bool TryAttachClipboardImages()
+    {
+        try
+        {
+            // Image files copied from Explorer come through as a file-drop list.
+            if (Clipboard.ContainsFileDropList())
+            {
+                var images = Clipboard.GetFileDropList().Cast<string>()
+                    .Where(ImageAttachmentHelper.IsSupportedImageFile).ToList();
+                if (images.Count > 0)
+                {
+                    foreach (var path in images)
+                        AddAttachment(ImageAttachmentHelper.FromFile(path));
+                    return true;
+                }
+            }
+
+            // A screenshot / copied image arrives as raw bitmap data (DIB/CF_BITMAP)
+            // and/or a PNG stream — some sources provide only the latter, which
+            // ContainsImage() doesn't report, so check both.
+            if (Clipboard.ContainsImage() || Clipboard.ContainsData("PNG"))
+            {
+                var attachment = ImageAttachmentHelper.FromClipboard();
+                if (attachment != null)
+                {
+                    AddAttachment(attachment);
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"AiChatControl: clipboard image paste failed — {ex.Message}");
+        }
+        return false;
+    }
+
+    private void InputPanel_PreviewDragOver(object sender, DragEventArgs e)
+    {
+        e.Effects = HasDroppableImages(e) ? DragDropEffects.Copy : DragDropEffects.None;
+        e.Handled = true;
+    }
+
+    private void InputPanel_PreviewDrop(object sender, DragEventArgs e)
+    {
+        if (!e.Data.GetDataPresent(DataFormats.FileDrop)
+            || e.Data.GetData(DataFormats.FileDrop) is not string[] files)
+            return;
+
+        var images = files.Where(ImageAttachmentHelper.IsSupportedImageFile).ToList();
+        if (images.Count == 0)
+            return;
+
+        foreach (var path in images)
+            AddAttachment(ImageAttachmentHelper.FromFile(path));
+        e.Handled = true;
+        FocusInput();
+    }
+
+    private static bool HasDroppableImages(DragEventArgs e)
+        => e.Data.GetDataPresent(DataFormats.FileDrop)
+           && e.Data.GetData(DataFormats.FileDrop) is string[] files
+           && files.Any(ImageAttachmentHelper.IsSupportedImageFile);
+
+    private void AddAttachment(PendingImageAttachment? attachment)
+    {
+        if (attachment != null)
+            PendingAttachments.Add(attachment);
+    }
+
+    private void RemoveAttachment_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { Tag: PendingImageAttachment a })
+            PendingAttachments.Remove(a);
+    }
+
+    // Click a chip's thumbnail to open the larger lightbox, from which the image
+    // can be removed (Gmail-style).
+    private void PreviewAttachment_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement { Tag: PendingImageAttachment a })
+            return;
+
+        var owner = Window.GetWindow(this)!;
+        var preview = ImageAttachmentHelper.CreatePreview(a);
+        if (ImagePreviewDialog.Show(owner, preview, a.DisplayName))
+            PendingAttachments.Remove(a);
+    }
+
+    // The Cancel (✕) button: discard the drafted text and any queued attachments.
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        InputBox.Text = "";
+        PendingAttachments.Clear();
+        FocusInput();
+    }
+
+    // Shows the attachments bar only when something is queued, and keeps the
+    // Cancel button in sync.
+    private void UpdateAttachmentsBar()
+    {
+        AttachmentsBar.Visibility = PendingAttachments.Count > 0
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        UpdateComposerButtons();
+    }
+
+    // The Cancel button is always visible (to avoid the composer resizing as it
+    // appears/disappears) but is only enabled when there's something to discard
+    // (drafted text or queued images).
+    private void UpdateComposerButtons()
+        => CancelButton.IsEnabled =
+            !string.IsNullOrEmpty(InputBox.Text) || PendingAttachments.Count > 0;
+
     // --- Message Collection Helpers ---
 
-    private void AddUserMessage(string text)
+    private void AddUserMessage(string text, IReadOnlyList<ImageSource>? images = null)
     {
         // Sending always snaps to the newest message, even if the user had
         // scrolled up to read history.
         _stickToBottom = true;
-        Messages.Add(new UserMessage(Guid.NewGuid(), text));
+        Messages.Add(new UserMessage(Guid.NewGuid(), text, images));
     }
 
     private void AddSystemMessage(string text, bool isWarning = false)
@@ -911,6 +1166,7 @@ public partial class AiChatControl : UserControl
         StopActivityAnimation();
         _activityVm?.Freeze();
         Messages.Clear();
+        PendingAttachments.Clear();
         _activityVm = null;
         _waitingVm = null;
         _inactivityVm = null;

--- a/src/AgentDock/Controls/GitStatusControl.xaml
+++ b/src/AgentDock/Controls/GitStatusControl.xaml
@@ -37,6 +37,15 @@
                 <TextBlock Text="&#xE712;" FontFamily="Segoe MDL2 Assets" FontSize="12"
                            Foreground="{DynamicResource GitPlaceholderForeground}" />
             </Button>
+            <Button x:Name="OpenRemoteButton" Click="OpenRemote_Click"
+                    ToolTip="Open repository in browser"
+                    Background="Transparent" BorderThickness="0"
+                    Padding="2" Margin="2,0,0,0" Cursor="Hand"
+                    Visibility="Collapsed"
+                    VerticalAlignment="Center">
+                <TextBlock Text="&#xE774;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                           Foreground="{DynamicResource GitPlaceholderForeground}" />
+            </Button>
 
             <!-- Branch picker popup -->
             <Popup x:Name="BranchPickerPopup"

--- a/src/AgentDock/Controls/GitStatusControl.xaml.cs
+++ b/src/AgentDock/Controls/GitStatusControl.xaml.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
@@ -48,6 +49,12 @@ public partial class GitStatusControl : UserControl
     private bool _refreshing;
     private bool _refreshQueued;
 
+    // Browsable web URL for origin, resolved once per repository (the remote origin
+    // doesn't change during a session) and cached so the debounced refresh doesn't
+    // shell out to git for it on every file change. Null = no browsable remote.
+    private string? _remoteWebUrl;
+    private bool _remoteResolved;
+
     public GitStatusControl()
     {
         InitializeComponent();
@@ -61,6 +68,9 @@ public partial class GitStatusControl : UserControl
         _projectPath = projectPath;
         _gitService = new GitService(projectPath);
         _isGitRepository = _gitService.IsGitRepository();
+        _remoteWebUrl = null;
+        _remoteResolved = false;
+        OpenRemoteButton.Visibility = Visibility.Collapsed;
 
         if (!_isGitRepository)
         {
@@ -217,6 +227,22 @@ public partial class GitStatusControl : UserControl
         var branch = BranchName.Text;
         if (!string.IsNullOrEmpty(branch))
             Clipboard.SetText(branch);
+    }
+
+    private void OpenRemote_Click(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrEmpty(_remoteWebUrl))
+            return;
+
+        try
+        {
+            // UseShellExecute lets the OS route the URL to the default browser.
+            Process.Start(new ProcessStartInfo(_remoteWebUrl) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"GitStatusControl: failed to open remote URL '{_remoteWebUrl}' — {ex.Message}");
+        }
     }
 
     private void BranchMore_Click(object sender, RoutedEventArgs e)
@@ -400,7 +426,10 @@ public partial class GitStatusControl : UserControl
         // the blocking git calls AND the post-processing (sort + the membership
         // set used to diff). Only the minimal merge into the bound collection
         // (SyncFileList) runs on the UI thread after we resume.
-        var (branch, target, targetSet) = await Task.Run(() =>
+        // The remote origin is resolved at most once (see _remoteResolved). Capture
+        // the current cache state before the hop so the closure reads no live fields.
+        var resolveRemote = !_remoteResolved;
+        var (branch, target, targetSet, remoteWebUrl) = await Task.Run(() =>
         {
             var b = gitService.GetCurrentBranch();
             var entries = gitService.GetStatus();
@@ -409,11 +438,22 @@ public partial class GitStatusControl : UserControl
                 .OrderBy(e => e.IsStaged ? 0 : 1)
                 .ThenBy(e => e.FilePath, StringComparer.OrdinalIgnoreCase)
                 .ToList();
-            return (b, sorted, new HashSet<GitFileEntry>(sorted));
+            var remote = resolveRemote ? gitService.GetRemoteWebUrl() : null;
+            return (b, sorted, new HashSet<GitFileEntry>(sorted), remote);
         });
 
         // The tab may have been deactivated/closed while git ran.
         if (!_active) return;
+
+        // Show the "open in browser" button once we've resolved a browsable remote.
+        if (resolveRemote)
+        {
+            _remoteWebUrl = remoteWebUrl;
+            _remoteResolved = true;
+            OpenRemoteButton.Visibility = string.IsNullOrEmpty(_remoteWebUrl)
+                ? Visibility.Collapsed
+                : Visibility.Visible;
+        }
 
         // Branch header
         if (!string.IsNullOrEmpty(branch))

--- a/src/AgentDock/MainWindow.xaml.cs
+++ b/src/AgentDock/MainWindow.xaml.cs
@@ -845,6 +845,9 @@ public partial class MainWindow : Window
         _projectDescriptionControls[project] = descControl;
         _projectTodoListControls[project] = todoControl;
         chatControl.SessionStateChanged += state => UpdateTabIcon(project, state);
+        // A scheduled message changes the tab's icon/tooltip even when the session
+        // state itself doesn't move (e.g. Idle → Idle-with-schedule), so refresh on it.
+        chatControl.ScheduleChanged += () => UpdateTabIcon(project, chatControl.CurrentState);
 
         // Switch to the new project
         SwitchToProject(project);
@@ -2915,11 +2918,23 @@ public partial class MainWindow : Window
         diamondIcon.Visibility = Visibility.Visible;
         _projectNewResponse.Remove(project); // recomputed below for the Idle/just-finished case
 
+        // A parked scheduled message replaces the quiet (idle / no-session) diamond with
+        // a clock glyph + tooltip. Active states (working/permission/error) and an unseen
+        // completion still take precedence \u2014 the schedule is the calmest signal.
+        var scheduledUtc = _projectChatControls.TryGetValue(project, out var schedChat)
+            ? schedChat.ScheduledFireTimeUtc
+            : null;
+
         switch (state)
         {
             case ClaudeSessionState.NotStarted:
             case ClaudeSessionState.Exited:
-                diamondIcon.Text = "\u25C7"; // ◇ outline diamond
+                if (scheduledUtc != null)
+                {
+                    ApplyScheduledVisual(diamondIcon);
+                    break;
+                }
+                diamondIcon.Text = "\u25C7"; //◇ outline diamond
                 diamondIcon.Foreground = ThemeManager.GetBrush("TabIconInactiveDiamondForeground");
                 break;
 
@@ -2939,6 +2954,10 @@ public partial class MainWindow : Window
                 {
                     _projectNewResponse.Add(project);
                     StartAttentionPulse(project, diamondIcon);
+                }
+                else if (scheduledUtc != null)
+                {
+                    ApplyScheduledVisual(diamondIcon);
                 }
                 break;
 
@@ -2963,8 +2982,34 @@ public partial class MainWindow : Window
                 break;
         }
 
+        UpdateTabScheduleTooltip(project, scheduledUtc);
+
         // Roll the child's new state up into its group's aggregate diamond.
         RefreshGroupIndicator(project.GroupId);
+    }
+
+    /// <summary>
+    /// Renders the "message scheduled" indicator: a clock glyph in the scheduled
+    /// accent colour, replacing the diamond. Used on both project and group tabs.
+    /// </summary>
+    private static void ApplyScheduledVisual(TextBlock icon)
+    {
+        icon.Text = "◷"; // ◷ circle-with-quadrant — reads as a clock/timer face
+        icon.Foreground = ThemeManager.GetBrush("TabIconScheduledForeground");
+    }
+
+    /// <summary>
+    /// Appends the scheduled fire time to the tab's tooltip while a message is parked,
+    /// reverting to just the folder path once it fires or is cancelled.
+    /// </summary>
+    private void UpdateTabScheduleTooltip(ProjectInfo project, DateTime? scheduledUtc)
+    {
+        if (!_projectTabButtons.TryGetValue(project, out var button))
+            return;
+
+        button.ToolTip = scheduledUtc is { } utc
+            ? $"{project.FolderPath}\nMessage scheduled for {utc.ToLocalTime():g}"
+            : project.FolderPath;
     }
 
     private void StartDiamondPulse(ProjectInfo project, TextBlock diamondIcon)
@@ -3020,6 +3065,10 @@ public partial class MainWindow : Window
             grid.Children[0] is TextBlock diamond)
         {
             diamond.Visibility = Visibility.Visible;
+            // A message may have been scheduled while this tab was flashing; with the
+            // completion now seen, the calm scheduled glyph takes over from the green.
+            if (chat.ScheduledFireTimeUtc != null)
+                ApplyScheduledVisual(diamond);
         }
 
         // The completion has now been seen — drop the group's flashing-green state.
@@ -3036,11 +3085,12 @@ public partial class MainWindow : Window
     private enum TabIndicator
     {
         Inactive = 0,    // hollow purple ◇ — no or ended session
-        Working = 1,     // flashing blue ◆
-        Idle = 2,        // solid green ◆ — ready, completion already seen
-        NewResponse = 3, // flashing green ◆ — completed turn the user hasn't viewed
-        Question = 4,    // solid orange ◆ — waiting for a permission answer
-        Error = 5,       // red ◆ + "!" — session error
+        Scheduled = 1,   // clock ◷ — a message is parked to send later (lowest signal)
+        Working = 2,     // flashing blue ◆
+        Idle = 3,        // solid green ◆ — ready, completion already seen
+        NewResponse = 4, // flashing green ◆ — completed turn the user hasn't viewed
+        Question = 5,    // solid orange ◆ — waiting for a permission answer
+        Error = 6,       // red ◆ + "!" — session error
     }
 
     private TabIndicator GetProjectIndicator(ProjectInfo project)
@@ -3048,15 +3098,18 @@ public partial class MainWindow : Window
         if (!_projectChatControls.TryGetValue(project, out var chat))
             return TabIndicator.Inactive;
 
+        var scheduled = chat.ScheduledFireTimeUtc != null;
         return chat.CurrentState switch
         {
             ClaudeSessionState.Error => TabIndicator.Error,
             ClaudeSessionState.WaitingForPermission => TabIndicator.Question,
             ClaudeSessionState.Idle =>
-                _projectNewResponse.Contains(project) ? TabIndicator.NewResponse : TabIndicator.Idle,
+                _projectNewResponse.Contains(project) ? TabIndicator.NewResponse
+                : scheduled ? TabIndicator.Scheduled
+                : TabIndicator.Idle,
             ClaudeSessionState.Working => TabIndicator.Working,
             ClaudeSessionState.Initializing => TabIndicator.Working,
-            _ => TabIndicator.Inactive, // NotStarted, Exited
+            _ => scheduled ? TabIndicator.Scheduled : TabIndicator.Inactive, // NotStarted, Exited
         };
     }
 
@@ -3096,6 +3149,10 @@ public partial class MainWindow : Window
             case TabIndicator.Inactive:
                 diamond.Text = "◇";
                 diamond.Foreground = ThemeManager.GetBrush("TabIconInactiveDiamondForeground");
+                break;
+
+            case TabIndicator.Scheduled:
+                ApplyScheduledVisual(diamond); // clock ◷ — no pulse, lowest-priority signal
                 break;
 
             case TabIndicator.Working:

--- a/src/AgentDock/Models/ChatMessages.cs
+++ b/src/AgentDock/Models/ChatMessages.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Windows.Documents;
+using System.Windows.Media;
 using System.Windows.Threading;
 
 namespace AgentDock.Models;
@@ -23,9 +24,16 @@ public abstract class ChatMessageVm(Guid id)
 
 // --- Immutable finalized messages ---
 
-public sealed class UserMessage(Guid id, string text) : ChatMessageVm(id)
+public sealed class UserMessage(Guid id, string text, IReadOnlyList<ImageSource>? images = null) : ChatMessageVm(id)
 {
     public string Text { get; } = text;
+
+    /// <summary>Thumbnails of any images attached to this message, shown above the
+    /// text in the bubble. Null/empty for text-only messages.</summary>
+    public IReadOnlyList<ImageSource>? Images { get; } = images;
+
+    public bool HasImages => Images is { Count: > 0 };
+    public bool HasText => !string.IsNullOrEmpty(Text);
 }
 
 /// <summary>
@@ -38,7 +46,7 @@ public sealed class UserMessage(Guid id, string text) : ChatMessageVm(id)
 /// cached) only when the bubble is actually realized in a visible tab, so
 /// background tabs and off-screen messages never pay the MdXaml + AvalonEdit build
 /// cost. The same closure is passed to the toggled instance so flipping the view
-/// doesn't re-parse. Null for single-line messages (rendered as plain text).
+/// doesn't re-parse. Null for messages with no markdown (rendered as plain text).
 /// </summary>
 public sealed class AssistantMessage(
     Guid id,
@@ -49,9 +57,10 @@ public sealed class AssistantMessage(
 {
     public string Text { get; } = text;
     public bool IsMarkdownView { get; } = isMarkdownView;
-    /// <summary>True for multi-line assistant text — the only case where the
-    /// source/rendered toggle button is meaningful (single-line messages have
-    /// nothing for the renderer to add).</summary>
+    /// <summary>True when the text carries markdown the renderer changes (multi-line
+    /// content, or inline emphasis / code / links / URLs) — the only case where the
+    /// source/rendered toggle button is meaningful. A plain single-line sentence has
+    /// nothing for the renderer to add, so it shows no toggle.</summary>
     public bool HasMarkdownToggle { get; } = hasMarkdownToggle;
 
     /// <summary>Memoizing factory for the rendered document; null if this message
@@ -65,6 +74,23 @@ public sealed class AssistantMessage(
 
 /// <summary>One green tool-execution line inside an <see cref="ActivityMessage"/>.</summary>
 public sealed record ToolEntry(string Name, string FormattedInput);
+
+/// <summary>A subagent / background-task spawn line inside an <see cref="ActivityMessage"/>.
+/// Rendered distinctly (diamond glyph, working accent colour) so a launched subagent
+/// stands apart from the main agent's own tool calls.</summary>
+public sealed record SubagentEntry(string Label, string Description);
+
+/// <summary>A subagent's final report inside an <see cref="ActivityMessage"/>, shown when
+/// the subagent completes. Carries the subagent type, the model it ran on (shown as a tag;
+/// null if unknown), and its final text — so the subagent's actual output is captured in
+/// the transcript rather than discarded.</summary>
+public sealed record SubagentReportEntry(string Label, string? Model, string Text)
+{
+    /// <summary>"◆ Explore report · claude-sonnet-5" style header.</summary>
+    public string Header => string.IsNullOrEmpty(Model)
+        ? $"◆ {Label} report"
+        : $"◆ {Label} report · {Model}";
+}
 
 public sealed class SystemMessage(Guid id, string text, bool isWarning) : ChatMessageVm(id)
 {
@@ -236,6 +262,20 @@ public sealed class ActivityMessage(Guid id) : ChatMessageVm(id), INotifyPropert
     {
         CloseThinking();
         Entries.Add(new ToolEntry(name, formattedInput));
+    }
+
+    /// <summary>Add a subagent / background-task spawn line; closes any open thinking block first.</summary>
+    public void AddSubagent(string label, string description)
+    {
+        CloseThinking();
+        Entries.Add(new SubagentEntry(label, description));
+    }
+
+    /// <summary>Add a completed subagent's final report; closes any open thinking block first.</summary>
+    public void AddSubagentReport(string label, string? model, string text)
+    {
+        CloseThinking();
+        Entries.Add(new SubagentReportEntry(label, model, text));
     }
 
     private void EnsureOpenThinking()

--- a/src/AgentDock/Models/ChatOps.cs
+++ b/src/AgentDock/Models/ChatOps.cs
@@ -37,6 +37,24 @@ public sealed record EnsureExecutionOp : ChatOp;
 /// <summary>Add a tool-call entry to the current execution bubble.</summary>
 public sealed record AddToolOp(string Name, string FormattedInput) : ChatOp;
 
+/// <summary>A subagent (or background task) was spawned — add a distinct entry to the
+/// activity bubble. <paramref name="Label"/> is the subagent type (e.g. "Explore"),
+/// "Background task", or "Workflow"; <paramref name="Description"/> is the short task
+/// description.</summary>
+public sealed record AddSubagentOp(string Label, string Description) : ChatOp;
+
+/// <summary>A subagent (task_type <c>local_agent</c>) finished and produced a final
+/// report. Rendered as a distinct entry so the subagent's actual output is captured in
+/// the transcript (previously discarded). <paramref name="Model"/> is the model the
+/// subagent ran on, shown as a tag; null if unknown.</summary>
+public sealed record AddSubagentReportOp(string Label, string? Model, string Text) : ChatOp;
+
+/// <summary>The counts of in-flight background work changed, split by kind so the
+/// working status line can say e.g. "2 subagents · 1 background task" rather than
+/// lumping background shells in with real subagents. Drives the live suffix on the
+/// working status line.</summary>
+public sealed record ActivityCountsOp(int Subagents, int BackgroundTasks, int Workflows) : ChatOp;
+
 /// <summary>Finalize the execution bubble into its immutable form.</summary>
 public sealed record FinalizeExecutionOp : ChatOp;
 

--- a/src/AgentDock/Models/ClaudeMessages.cs
+++ b/src/AgentDock/Models/ClaudeMessages.cs
@@ -32,8 +32,48 @@ public class ClaudeMessagePayload
     [JsonPropertyName("role")]
     public string Role { get; init; } = "user";
 
+    /// <summary>
+    /// Either a plain string (the common text-only case) or a list of content
+    /// blocks (<see cref="ClaudeTextBlock"/> / <see cref="ClaudeImageBlock"/>) when
+    /// the message carries images. Declared <c>object</c> so System.Text.Json
+    /// serializes the runtime type — a bare string stays a JSON string, a list
+    /// becomes the Anthropic content-block array.
+    /// </summary>
     [JsonPropertyName("content")]
-    public string Content { get; init; } = "";
+    public object Content { get; init; } = "";
+}
+
+/// <summary>A text content block within a multimodal user message.</summary>
+public class ClaudeTextBlock
+{
+    [JsonPropertyName("type")]
+    public string Type => "text";
+
+    [JsonPropertyName("text")]
+    public string Text { get; init; } = "";
+}
+
+/// <summary>An image content block within a multimodal user message.</summary>
+public class ClaudeImageBlock
+{
+    [JsonPropertyName("type")]
+    public string Type => "image";
+
+    [JsonPropertyName("source")]
+    public ClaudeImageSource Source { get; init; } = null!;
+}
+
+/// <summary>Base64 image source for a <see cref="ClaudeImageBlock"/>.</summary>
+public class ClaudeImageSource
+{
+    [JsonPropertyName("type")]
+    public string Type => "base64";
+
+    [JsonPropertyName("media_type")]
+    public string MediaType { get; init; } = "";
+
+    [JsonPropertyName("data")]
+    public string Data { get; init; } = "";
 }
 
 /// <summary>
@@ -136,6 +176,48 @@ public class ClaudeAssistantMessage
 {
     public string Uuid { get; init; } = "";
     public List<ClaudeContentBlock> Content { get; init; } = [];
+
+    /// <summary>The model that produced this message (from <c>message.model</c>),
+    /// e.g. "claude-sonnet-5", "claude-fable-5". Null if absent. Used to attribute a
+    /// subagent's report to the model it ran on (Fable for planning, Opus/Sonnet for
+    /// execution).</summary>
+    public string? Model { get; init; }
+
+    /// <summary>
+    /// Non-null when this message was produced <i>by</i> a subagent — it carries the
+    /// <c>tool_use_id</c> of the spawning <c>Agent</c>/<c>Task</c> tool call. Null for
+    /// main-session messages. Used to keep subagent-internal tool calls and text out
+    /// of the top-level transcript (their activity is summarized by the subagent entry
+    /// and the running-count indicator instead).
+    /// </summary>
+    public string? ParentToolUseId { get; init; }
+}
+
+/// <summary>
+/// A subagent / background-task lifecycle event, parsed from the CLI's
+/// <c>system</c> messages (subtypes <c>task_started</c>, <c>task_progress</c>,
+/// <c>task_updated</c>, <c>task_notification</c>). These let us show that a
+/// subagent (<c>task_type: local_agent</c>) or a background shell is still running
+/// after the main agent's text has returned.
+/// </summary>
+public class ClaudeTaskEvent
+{
+    /// <summary>The system subtype: task_started / task_progress / task_updated / task_notification.</summary>
+    public string Subtype { get; init; } = "";
+    public string TaskId { get; init; } = "";
+    public string? ToolUseId { get; init; }
+    public string? Description { get; init; }
+    /// <summary>e.g. "Explore", "general-purpose" — present for subagents.</summary>
+    public string? SubagentType { get; init; }
+    /// <summary>e.g. "local_agent" for subagents; absent/other for background shells.</summary>
+    public string? TaskType { get; init; }
+    /// <summary>Lifecycle status: running / completed / killed / stopped / failed / …
+    /// For task_updated it is read from the nested <c>patch.status</c>.</summary>
+    public string? Status { get; init; }
+
+    /// <summary>True once the task has reached a terminal state (no longer running).</summary>
+    public bool IsTerminal => Status is "completed" or "killed" or "stopped"
+        or "failed" or "error" or "cancelled" or "timed_out";
 }
 
 /// <summary>

--- a/src/AgentDock/Models/ImageAttachment.cs
+++ b/src/AgentDock/Models/ImageAttachment.cs
@@ -1,0 +1,27 @@
+using System.Windows.Media;
+
+namespace AgentDock.Models;
+
+/// <summary>
+/// An image attached to a user message, ready to serialize into a Claude Code
+/// <c>image</c> content block. <see cref="Base64Data"/> is the raw (already
+/// resized/encoded) image bytes base64-encoded; <see cref="MediaType"/> is the
+/// MIME type Claude expects (e.g. <c>image/png</c>, <c>image/jpeg</c>).
+/// </summary>
+public sealed record ImageAttachment(string MediaType, string Base64Data);
+
+/// <summary>
+/// UI-side view-model for an image queued in the input area before send. Holds a
+/// small frozen <see cref="Thumbnail"/> for the chip / message bubble plus the
+/// normalized image bytes that become an <see cref="ImageAttachment"/> on send.
+/// Immutable — created by <c>ImageAttachmentHelper</c>.
+/// </summary>
+public sealed class PendingImageAttachment
+{
+    public required ImageSource Thumbnail { get; init; }
+    public required string DisplayName { get; init; }
+    public required string MediaType { get; init; }
+    public required byte[] Data { get; init; }
+
+    public ImageAttachment ToAttachment() => new(MediaType, Convert.ToBase64String(Data));
+}

--- a/src/AgentDock/Models/QueuedMessage.cs
+++ b/src/AgentDock/Models/QueuedMessage.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Media;
+
+namespace AgentDock.Models;
+
+/// <summary>
+/// One message waiting in a chat's send queue (its "outbox"). Queued items are
+/// dispatched to Claude in strict FIFO order — one after the previous turn returns —
+/// which is what lets the user line up several tasks while the agent is busy.
+///
+/// <para><see cref="NotBeforeUtc"/> optionally gates an item behind a wall-clock time:
+/// <c>null</c> means "send as soon as this reaches the head of the queue and the
+/// session is idle" (a plain <b>queued</b> message); a value means "…and not before
+/// this time" (a <b>scheduled</b> message). This single shape covers both features and
+/// composes: a timed item followed by plain items runs the timed one first (when it
+/// comes due), then the rest — e.g. "schedule for +1h, then queue a follow-up after
+/// it returns".</para>
+///
+/// Implements INPC only for <see cref="StatusText"/>, the live "Queued / Scheduled ·
+/// 04:59" label the queue panel row shows; everything else is set once at enqueue.
+/// </summary>
+public sealed class QueuedMessage : INotifyPropertyChanged
+{
+    public Guid Id { get; } = Guid.NewGuid();
+
+    public required string Text { get; init; }
+
+    /// <summary>Image payloads to send with the message; empty for text-only.</summary>
+    public IReadOnlyList<ImageAttachment> Attachments { get; init; } = [];
+
+    /// <summary>Frozen thumbnails for the sent user bubble; null when text-only.</summary>
+    public IReadOnlyList<ImageSource>? Thumbnails { get; init; }
+
+    /// <summary>UTC time before which this must not be sent; null = send when it
+    /// reaches the head of the queue.</summary>
+    public DateTime? NotBeforeUtc { get; init; }
+
+    public bool IsScheduled => NotBeforeUtc.HasValue;
+
+    /// <summary>Single-line, length-capped preview of the message for the queue row.</summary>
+    public string Preview => BuildPreview(Text);
+
+    private string _statusText = "";
+    /// <summary>Live status shown in the queue panel ("Queued", "Scheduled · 04:59",
+    /// "Scheduled · due"). Refreshed by the control's per-second queue timer.</summary>
+    public string StatusText
+    {
+        get => _statusText;
+        private set
+        {
+            if (_statusText == value) return;
+            _statusText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>Recomputes <see cref="StatusText"/> for the current time.</summary>
+    public void RefreshStatus(DateTime nowUtc)
+    {
+        if (NotBeforeUtc is DateTime fireAt)
+        {
+            var remaining = fireAt - nowUtc;
+            StatusText = remaining > TimeSpan.Zero
+                ? $"Scheduled · {FormatCountdown(remaining)}"
+                : "Scheduled · due";
+        }
+        else
+        {
+            StatusText = "Queued";
+        }
+    }
+
+    private static string FormatCountdown(TimeSpan remaining)
+        => remaining.TotalHours >= 1
+            ? $"{(int)remaining.TotalHours:D2}:{remaining.Minutes:D2}:{remaining.Seconds:D2}"
+            : $"{remaining.Minutes:D2}:{remaining.Seconds:D2}";
+
+    private static string BuildPreview(string text)
+    {
+        // Collapse to one line so a multi-line draft doesn't blow out the row height.
+        var oneLine = text.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        const int cap = 100;
+        return oneLine.Length <= cap ? oneLine : oneLine[..cap] + "…";
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/src/AgentDock/Services/ChatTurnProcessor.cs
+++ b/src/AgentDock/Services/ChatTurnProcessor.cs
@@ -36,11 +36,33 @@ public sealed class ChatTurnProcessor
     private string _pendingText = "";
     private bool _pendingHasText;
 
+    // In-flight background work this turn, keyed by task_id, split by kind so the live
+    // indicator can distinguish real subagents from background shells. Driven by the
+    // CLI's task_* system events. The CLI reports THREE task_types — local_agent (a real
+    // subagent), local_bash (a run_in_background shell), local_workflow — which we
+    // previously lumped together and all mislabelled "subagents".
+    private enum TaskKind { Subagent, Background, Workflow }
+    private readonly Dictionary<string, TaskKind> _activeTasks = [];
+
+    // For local_agent tasks only: the accumulating final report, so a subagent's actual
+    // output is surfaced when it completes instead of being discarded. Same object is
+    // indexed by the spawning Agent tool_use_id (to route the subagent's own assistant
+    // text in via parent_tool_use_id) and by task_id (to emit it on the terminal event).
+    private sealed class SubagentReport
+    {
+        public string Label = "";
+        public string? Model;
+        public string LatestText = "";
+    }
+    private readonly Dictionary<string, SubagentReport> _subagentByToolUse = [];
+    private readonly Dictionary<string, SubagentReport> _subagentByTaskId = [];
+
     public void Attach(ClaudeSession session)
     {
         session.StreamDelta += OnStreamDelta;
         session.AssistantMessageReceived += OnAssistantMessage;
         session.ResultReceived += OnResult;
+        session.TaskEvent += OnTaskEvent;
     }
 
     /// <summary>Clears classification state. Call when the UI hard-resets the
@@ -51,6 +73,9 @@ public sealed class ChatTurnProcessor
         _lastThinkingBlockIndex = -1;
         _pendingText = "";
         _pendingHasText = false;
+        _activeTasks.Clear();
+        _subagentByToolUse.Clear();
+        _subagentByTaskId.Clear();
     }
 
     private void Emit(List<ChatOp> ops)
@@ -100,6 +125,17 @@ public sealed class ChatTurnProcessor
 
     private void OnAssistantMessage(ClaudeAssistantMessage msg)
     {
+        // Messages produced by a subagent carry the spawning Agent tool's id. Their
+        // internal tool calls still don't belong in the top-level transcript (they'd leak
+        // in as if the main agent ran them), but we no longer throw the whole message away:
+        // we capture the subagent's latest text as its final report, surfaced when it
+        // completes. (Its raw tool rows are still dropped.)
+        if (msg.ParentToolUseId != null)
+        {
+            CaptureSubagentText(msg);
+            return;
+        }
+
         var ops = new List<ChatOp> { new RemoveInactivityOp() };
 
         var toolBlocks = msg.Content.Where(c => c.Type == "tool_use").ToList();
@@ -117,6 +153,12 @@ public sealed class ChatTurnProcessor
 
             foreach (var block in toolBlocks)
             {
+                // The subagent-spawn tool itself (Agent/Task) is rendered as a distinct
+                // subagent entry from the richer task_started system event — skip the raw
+                // tool row so it isn't shown twice.
+                if (block.Name is "Agent" or "Task")
+                    continue;
+
                 var inputStr = "";
                 if (block.Input is JsonElement input)
                 {
@@ -164,6 +206,107 @@ public sealed class ChatTurnProcessor
         ops.Add(new TurnCompleteOp(result));
         Emit(ops);
         Reset();
+    }
+
+    // Subagent / background-task lifecycle. task_started adds a distinct entry and bumps
+    // the running count for its kind; a terminal task_updated/task_notification drops the
+    // count and, for a real subagent, surfaces its captured final report. The split counts
+    // feed the "N subagents · M background tasks" suffix on the working status line, so the
+    // user can see what kind of work is still in flight even after the main agent's text
+    // returns.
+    private void OnTaskEvent(ClaudeTaskEvent evt)
+    {
+        var ops = new List<ChatOp>();
+
+        if (evt.Subtype == "task_started")
+        {
+            // First sighting of this task — classify, render its entry, count it.
+            if (!_activeTasks.ContainsKey(evt.TaskId))
+            {
+                var kind = ClassifyTask(evt.TaskType);
+                _activeTasks[evt.TaskId] = kind;
+
+                var label = LabelFor(kind, evt.SubagentType);
+                ops.Add(new AddSubagentOp(label, evt.Description ?? ""));
+
+                // Only real subagents produce a report worth surfacing; start capturing
+                // it, indexed both ways so child text (by tool_use_id) and the terminal
+                // event (by task_id) can find the same accumulator.
+                if (kind == TaskKind.Subagent && evt.ToolUseId != null)
+                {
+                    var report = new SubagentReport { Label = label };
+                    _subagentByToolUse[evt.ToolUseId] = report;
+                    _subagentByTaskId[evt.TaskId] = report;
+                }
+
+                ops.Add(BuildCountsOp());
+            }
+        }
+        else if (evt.IsTerminal)
+        {
+            // Completed / killed / stopped — stop counting it as running.
+            if (_activeTasks.Remove(evt.TaskId))
+            {
+                // If it was a subagent that produced text, surface its final report now.
+                if (_subagentByTaskId.Remove(evt.TaskId, out var report)
+                    && report.LatestText.Length > 0)
+                {
+                    ops.Add(new AddSubagentReportOp(report.Label, report.Model, report.LatestText));
+                }
+                ops.Add(BuildCountsOp());
+            }
+        }
+
+        Emit(ops);
+    }
+
+    // Records a subagent's own assistant text as its (running) final report. Each subagent
+    // assistant line carries one text block; we keep the LATEST non-empty one — a
+    // subagent's last text is almost always its conclusion. Tool_use blocks are ignored
+    // (their raw rows don't belong in the top-level transcript).
+    private void CaptureSubagentText(ClaudeAssistantMessage msg)
+    {
+        if (msg.ParentToolUseId == null
+            || !_subagentByToolUse.TryGetValue(msg.ParentToolUseId, out var report))
+            return;
+
+        if (msg.Model != null)
+            report.Model = msg.Model;
+
+        var text = string.Concat(msg.Content
+            .Where(c => c.Type == "text" && c.Text != null)
+            .Select(c => c.Text));
+        if (text.Length > 0)
+            report.LatestText = text;
+    }
+
+    private static TaskKind ClassifyTask(string? taskType) => taskType switch
+    {
+        "local_agent" => TaskKind.Subagent,
+        "local_workflow" => TaskKind.Workflow,
+        _ => TaskKind.Background, // local_bash and anything else
+    };
+
+    private static string LabelFor(TaskKind kind, string? subagentType) => kind switch
+    {
+        TaskKind.Subagent => !string.IsNullOrEmpty(subagentType) ? subagentType! : "Subagent",
+        TaskKind.Workflow => "Workflow",
+        _ => "Background task",
+    };
+
+    private ActivityCountsOp BuildCountsOp()
+    {
+        int subagents = 0, background = 0, workflows = 0;
+        foreach (var kind in _activeTasks.Values)
+        {
+            switch (kind)
+            {
+                case TaskKind.Subagent: subagents++; break;
+                case TaskKind.Workflow: workflows++; break;
+                default: background++; break;
+            }
+        }
+        return new ActivityCountsOp(subagents, background, workflows);
     }
 
     private void FlushPendingAsCommentary(List<ChatOp> ops)

--- a/src/AgentDock/Services/ClaudeSession.cs
+++ b/src/AgentDock/Services/ClaudeSession.cs
@@ -47,6 +47,9 @@ public class ClaudeSession : IDisposable
     public event Action<ClaudeContentBlockEvent>? ContentBlockStopped;
     public event Action<ClaudePermissionRequest>? PermissionRequested;
     public event Action<ClaudeResultMessage>? ResultReceived;
+    /// <summary>Raised on subagent / background-task lifecycle events (task_started,
+    /// task_progress, task_updated, task_notification).</summary>
+    public event Action<ClaudeTaskEvent>? TaskEvent;
     public event Action<string>? ErrorOutput;
     public event Action<int>? ProcessExited;
     public event Action? InactivityTimeout;
@@ -153,8 +156,11 @@ public class ClaudeSession : IDisposable
     /// <summary>
     /// Sends a user message by spawning a one-shot claude process.
     /// Uses --resume to continue the conversation if a session ID exists.
+    /// Pass <paramref name="images"/> to attach images as Anthropic <c>image</c>
+    /// content blocks; when empty the message is sent as a plain string
+    /// (unchanged from the text-only path).
     /// </summary>
-    public void SendMessage(string text)
+    public void SendMessage(string text, IReadOnlyList<ImageAttachment>? images = null)
     {
         if (State != ClaudeSessionState.Idle)
             throw new InvalidOperationException($"Cannot send message in state {State}");
@@ -253,11 +259,7 @@ public class ClaudeSession : IDisposable
         // Send the user message as JSON on stdin — this is what actually
         // triggers Claude to start processing (with stream-json input,
         // the CLI reads from stdin, not from -p).
-        var userMessage = new ClaudeUserMessage
-        {
-            Message = new ClaudeMessagePayload { Content = text }
-        };
-        WriteStdin(JsonSerializer.Serialize(userMessage, JsonOptions));
+        WriteStdin(SerializeUserMessage(text, images));
     }
 
     /// <summary>
@@ -413,6 +415,38 @@ public class ClaudeSession : IDisposable
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
     };
 
+    /// <summary>
+    /// Serializes a user message for stdin. Text-only messages serialize with a
+    /// plain string <c>content</c> (unchanged from before image support); messages
+    /// with images serialize <c>content</c> as an Anthropic content-block array.
+    /// Public so the protocol shape can be locked by tests.
+    /// </summary>
+    public static string SerializeUserMessage(string text, IReadOnlyList<ImageAttachment>? images)
+        => JsonSerializer.Serialize(
+            new ClaudeUserMessage { Message = new ClaudeMessagePayload { Content = BuildUserContent(text, images) } },
+            JsonOptions);
+
+    /// <summary>
+    /// Builds the <c>content</c> value: a plain string when there are no images,
+    /// otherwise a list of content blocks (images first, then the text block when
+    /// non-empty) matching the Anthropic Messages API shape.
+    /// </summary>
+    private static object BuildUserContent(string text, IReadOnlyList<ImageAttachment>? images)
+    {
+        if (images is not { Count: > 0 })
+            return text;
+
+        var blocks = new List<object>(images.Count + 1);
+        foreach (var img in images)
+            blocks.Add(new ClaudeImageBlock
+            {
+                Source = new ClaudeImageSource { MediaType = img.MediaType, Data = img.Base64Data }
+            });
+        if (!string.IsNullOrEmpty(text))
+            blocks.Add(new ClaudeTextBlock { Text = text });
+        return blocks;
+    }
+
     private void WriteStdin(string json)
     {
         if (_process == null || _process.HasExited)
@@ -544,6 +578,13 @@ public class ClaudeSession : IDisposable
     private void HandleSystemMessage(JsonElement root)
     {
         var subtype = root.TryGetProperty("subtype", out var st) ? st.GetString() : null;
+
+        if (subtype is "task_started" or "task_progress" or "task_updated" or "task_notification")
+        {
+            HandleTaskEvent(subtype, root);
+            return;
+        }
+
         if (subtype != "init")
             return;
 
@@ -559,11 +600,45 @@ public class ClaudeSession : IDisposable
             Model = newModel;
     }
 
+    /// <summary>
+    /// Parses a subagent / background-task lifecycle system message and raises
+    /// <see cref="TaskEvent"/>. The status for <c>task_updated</c> lives in a nested
+    /// <c>patch.status</c>; the others carry it (when present) at the top level.
+    /// </summary>
+    private void HandleTaskEvent(string subtype, JsonElement root)
+    {
+        var taskId = GetString(root, "task_id");
+        if (taskId == null)
+            return;
+
+        var status = GetString(root, "status");
+        if (status == null && root.TryGetProperty("patch", out var patch) && patch.ValueKind == JsonValueKind.Object)
+            status = GetString(patch, "status");
+
+        var evt = new ClaudeTaskEvent
+        {
+            Subtype = subtype,
+            TaskId = taskId,
+            ToolUseId = GetString(root, "tool_use_id"),
+            Description = GetString(root, "description"),
+            SubagentType = GetString(root, "subagent_type"),
+            TaskType = GetString(root, "task_type"),
+            Status = status
+        };
+
+        Log.Info($"ClaudeSession: task {subtype} id={taskId} status={status ?? "-"} type={evt.TaskType ?? "-"} agent={evt.SubagentType ?? "-"}");
+        TaskEvent?.Invoke(evt);
+    }
+
     private void HandleAssistantMessage(JsonElement root)
     {
         var msg = new ClaudeAssistantMessage
         {
-            Uuid = GetString(root, "uuid") ?? ""
+            Uuid = GetString(root, "uuid") ?? "",
+            ParentToolUseId = GetString(root, "parent_tool_use_id"),
+            Model = root.TryGetProperty("message", out var msgForModel)
+                ? GetString(msgForModel, "model")
+                : null
         };
 
         if (root.TryGetProperty("message", out var message) &&
@@ -664,6 +739,21 @@ public class ClaudeSession : IDisposable
             CacheReadInputTokens = cacheRead,
             CacheCreationInputTokens = cacheCreation
         };
+
+        // A result with num_turns == 0 is NOT this turn completing. When a session is
+        // resumed (--resume) with an orphaned background shell left over from a previous
+        // turn, the CLI emits an empty, zero-cost "flush" result (num_turns:0, result:"")
+        // BEFORE it processes the user's message — the real init + turn follow it on the
+        // same process. Treating that as completion drops the session to Idle the instant
+        // the user sends, firing the completion chime and a $0 cost line prematurely.
+        // Ignore it and stay Working; the real result (num_turns >= 1) that follows
+        // completes the turn. A genuine reply is always >= 1 turn; error results are let
+        // through so real failures still surface.
+        if (result.NumTurns == 0 && !result.IsError)
+        {
+            Log.Info("ClaudeSession: ignoring resume-flush result (num_turns=0) — real turn follows");
+            return;
+        }
 
         // Process finished this turn — stop the watchdog, close stdin so the process
         // exits cleanly, then transition back to idle. Next SendMessage will spawn a

--- a/src/AgentDock/Services/GitService.cs
+++ b/src/AgentDock/Services/GitService.cs
@@ -102,6 +102,102 @@ public class GitService
         return result;
     }
 
+    /// <summary>
+    /// Returns a browsable web URL for the <c>origin</c> remote, or null if there is
+    /// no origin or it isn't a recognizable web host (e.g. a plain SSH git server).
+    /// </summary>
+    public string? GetRemoteWebUrl()
+    {
+        var url = RunGit("remote get-url origin")?.Trim();
+        return ToWebUrl(url);
+    }
+
+    /// <summary>
+    /// Converts a git remote URL into a browsable https web URL, or returns null when
+    /// the remote can't be mapped to a web page. Pure/testable — no process launch.
+    ///
+    /// Rules:
+    /// - http(s) remotes are already web URLs → returned cleaned (credentials and a
+    ///   trailing <c>.git</c> stripped). Covers self-hosted GitHub/GitLab over https.
+    /// - SSH remotes (scp-style <c>git@host:path</c> or <c>ssh://…</c>) are converted
+    ///   only for recognized web hosts, since an arbitrary SSH git server isn't a web
+    ///   server. Azure DevOps uses a distinct web-path shape and is special-cased.
+    /// </summary>
+    public static string? ToWebUrl(string? remoteUrl)
+    {
+        if (string.IsNullOrWhiteSpace(remoteUrl))
+            return null;
+
+        var url = remoteUrl.Trim();
+
+        // http(s): already a web URL. Strip embedded credentials + trailing ".git".
+        if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.Host))
+                return null;
+
+            var httpPath = StripDotGit(uri.AbsolutePath).TrimEnd('/');
+            if (string.IsNullOrEmpty(httpPath))
+                return null;
+
+            return $"https://{uri.Host}{httpPath}";
+        }
+
+        // Otherwise SSH — extract (host, path).
+        string? host;
+        string? path;
+        if (url.StartsWith("ssh://", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                return null;
+            host = uri.Host;
+            path = uri.AbsolutePath;
+        }
+        else
+        {
+            // scp-like: [user@]host:path
+            var afterUser = url.Contains('@') ? url[(url.IndexOf('@') + 1)..] : url;
+            var colon = afterUser.IndexOf(':');
+            if (colon <= 0)
+                return null;
+            host = afterUser[..colon];
+            path = afterUser[(colon + 1)..];
+        }
+
+        if (string.IsNullOrEmpty(host) || string.IsNullOrEmpty(path))
+            return null;
+
+        path = StripDotGit(path.Trim('/'));
+        if (string.IsNullOrEmpty(path))
+            return null;
+
+        // Azure DevOps SSH: v3/{org}/{project}/{repo} -> dev.azure.com/{org}/{project}/_git/{repo}
+        if (host.Equals("ssh.dev.azure.com", StringComparison.OrdinalIgnoreCase) ||
+            host.Equals("vs-ssh.visualstudio.com", StringComparison.OrdinalIgnoreCase))
+        {
+            var parts = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 4 && parts[0].Equals("v3", StringComparison.OrdinalIgnoreCase))
+                return $"https://dev.azure.com/{parts[1]}/{parts[2]}/_git/{parts[3]}";
+            return null;
+        }
+
+        return IsKnownWebHost(host) ? $"https://{host}/{path}" : null;
+    }
+
+    private static string StripDotGit(string s)
+        => s.EndsWith(".git", StringComparison.OrdinalIgnoreCase) ? s[..^4] : s;
+
+    private static bool IsKnownWebHost(string host)
+    {
+        host = host.ToLowerInvariant();
+        string[] known = ["github.com", "gitlab.com", "bitbucket.org", "dev.azure.com", "codeberg.org"];
+        return known.Contains(host)
+            || host.Contains("github")
+            || host.Contains("gitlab")
+            || host.Contains("bitbucket");
+    }
+
     public List<string> GetLocalBranches()
     {
         var output = RunGit("branch --format=%(refname:short)");

--- a/src/AgentDock/Services/ImageAttachmentHelper.cs
+++ b/src/AgentDock/Services/ImageAttachmentHelper.cs
@@ -1,0 +1,191 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using AgentDock.Models;
+
+namespace AgentDock.Services;
+
+/// <summary>
+/// Turns pasted/dropped images into <see cref="PendingImageAttachment"/>s: decodes
+/// (any format WPF can read), downscales to Claude's recommended max edge, and
+/// re-encodes to PNG — falling back to JPEG when the PNG would exceed the size the
+/// API accepts. Output media type is therefore always one Claude supports
+/// (<c>image/png</c> or <c>image/jpeg</c>), regardless of the source format.
+/// </summary>
+public static class ImageAttachmentHelper
+{
+    // Anthropic resizes anything larger than ~1568px on the long edge, so there's
+    // no benefit to sending bigger — downscale first to keep payloads small.
+    private const int MaxEdge = 1568;
+
+    // The API caps a base64 image at ~5 MB; base64 inflates by ~4/3, so keep the
+    // raw encoded bytes under ~3.6 MB. PNGs of photos blow past this, hence the
+    // JPEG fallback.
+    private const long MaxRawBytes = 3_600_000;
+
+    // Long edge of the in-app thumbnail kept on the VM (chip + message bubble).
+    private const int ThumbnailEdge = 200;
+
+    private static readonly HashSet<string> SupportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tif", ".tiff", ".webp"
+    };
+
+    public static bool IsSupportedImageFile(string path)
+        => SupportedExtensions.Contains(Path.GetExtension(path));
+
+    /// <summary>
+    /// Decodes the (already downscaled/normalized) attachment bytes into a frozen
+    /// bitmap for the enlarged lightbox preview. Falls back to the small thumbnail
+    /// if decoding somehow fails.
+    /// </summary>
+    public static ImageSource CreatePreview(PendingImageAttachment attachment)
+    {
+        try
+        {
+            var bmp = new BitmapImage();
+            using var ms = new MemoryStream(attachment.Data);
+            bmp.BeginInit();
+            bmp.CacheOption = BitmapCacheOption.OnLoad;
+            bmp.StreamSource = ms;
+            bmp.EndInit();
+            bmp.Freeze();
+            return bmp;
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"ImageAttachment: failed to decode preview — {ex.Message}");
+            return attachment.Thumbnail;
+        }
+    }
+
+    /// <summary>
+    /// Builds an attachment from an image file on disk. Returns null (and logs) if
+    /// the file can't be decoded.
+    /// </summary>
+    public static PendingImageAttachment? FromFile(string path)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            var decoder = BitmapDecoder.Create(stream,
+                BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.OnLoad);
+            if (decoder.Frames.Count == 0)
+                return null;
+            return Build(decoder.Frames[0], Path.GetFileName(path));
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"ImageAttachment: failed to load '{path}' — {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Builds an attachment from whatever image is currently on the clipboard,
+    /// preferring the raw <c>PNG</c> stream (what the Windows Snipping Tool, browsers,
+    /// and most editors place there) over the CF_DIB / CF_BITMAP that
+    /// <see cref="Clipboard.GetImage"/> reads — the DIB path drops the alpha channel
+    /// and renders screenshots with a black background on some sources. Returns null
+    /// (and logs) if the clipboard has no usable image.
+    /// </summary>
+    public static PendingImageAttachment? FromClipboard()
+    {
+        try
+        {
+            // Prefer PNG: decode the stream directly so transparency survives.
+            if (Clipboard.ContainsData("PNG") && Clipboard.GetData("PNG") is MemoryStream png && png.Length > 0)
+            {
+                png.Position = 0;
+                var decoder = BitmapDecoder.Create(png,
+                    BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.OnLoad);
+                if (decoder.Frames.Count > 0)
+                    return Build(decoder.Frames[0], "Pasted image");
+            }
+
+            // Fall back to the standard bitmap accessor (DIB / CF_BITMAP).
+            if (Clipboard.ContainsImage())
+            {
+                var bmp = Clipboard.GetImage();
+                if (bmp != null)
+                    return Build(bmp, "Pasted image");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"ImageAttachment: failed to read clipboard image — {ex.Message}");
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Builds an attachment from an in-memory bitmap (e.g. a pasted screenshot).
+    /// Returns null (and logs) on failure.
+    /// </summary>
+    public static PendingImageAttachment? FromBitmap(BitmapSource source, string displayName)
+    {
+        try
+        {
+            return Build(source, displayName);
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"ImageAttachment: failed to process bitmap — {ex.Message}");
+            return null;
+        }
+    }
+
+    private static PendingImageAttachment Build(BitmapSource source, string displayName)
+    {
+        var scaled = Downscale(source, MaxEdge);
+
+        // Prefer PNG (lossless); fall back to JPEG when it's too large to send.
+        var (data, mediaType) = Encode(scaled);
+
+        var thumbnail = Downscale(source, ThumbnailEdge);
+        thumbnail.Freeze();
+
+        return new PendingImageAttachment
+        {
+            Thumbnail = thumbnail,
+            DisplayName = displayName,
+            MediaType = mediaType,
+            Data = data
+        };
+    }
+
+    private static (byte[] Data, string MediaType) Encode(BitmapSource image)
+    {
+        var png = EncodeWith(new PngBitmapEncoder(), image);
+        if (png.LongLength <= MaxRawBytes)
+            return (png, "image/png");
+
+        var jpeg = EncodeWith(new JpegBitmapEncoder { QualityLevel = 85 }, image);
+        Log.Info($"ImageAttachment: PNG was {png.LongLength} bytes (> {MaxRawBytes}); using JPEG ({jpeg.LongLength} bytes)");
+        return (jpeg, "image/jpeg");
+    }
+
+    private static byte[] EncodeWith(BitmapEncoder encoder, BitmapSource image)
+    {
+        encoder.Frames.Add(BitmapFrame.Create(image));
+        using var ms = new MemoryStream();
+        encoder.Save(ms);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Returns <paramref name="source"/> scaled down so its longest edge is at most
+    /// <paramref name="maxEdge"/>. Images already within bounds are returned as-is.
+    /// </summary>
+    private static BitmapSource Downscale(BitmapSource source, int maxEdge)
+    {
+        var longest = Math.Max(source.PixelWidth, source.PixelHeight);
+        if (longest <= maxEdge)
+            return source;
+
+        var scale = (double)maxEdge / longest;
+        var scaled = new TransformedBitmap(source, new ScaleTransform(scale, scale));
+        return scaled;
+    }
+}

--- a/src/AgentDock/Services/MarkdownHelper.cs
+++ b/src/AgentDock/Services/MarkdownHelper.cs
@@ -29,14 +29,27 @@ public static partial class MarkdownHelper
     [GeneratedRegex(@"\A#\s+v?\d+(\.\d+)+[^\r\n]*\r?\n(\r?\n)?")]
     private static partial Regex LeadingVersionHeadingRegex();
 
-    // **...** containing at least one inline atom (code span or link). MdXaml parses
-    // those atoms before bold, which leaves the ** delimiters orphaned around the
-    // atom and renders them as literal text. We split the bold around each atom.
-    [GeneratedRegex(@"\*\*([^*\n]*?(?:`[^`\n]+`|\[[^\]\n]+\]\([^)\n]+\))[^*\n]*?)\*\*")]
-    private static partial Regex BoldContainingInlineRegex();
-
     [GeneratedRegex(@"`[^`\n]+`|\[[^\]\n]+\]\([^)\n]+\)")]
     private static partial Regex InlineAtomRegex();
+
+    // Inline markdown constructs that make an otherwise single-line message worth
+    // rendering: bold/italic emphasis, an inline code span, a [text](url) link, or a
+    // bare URL. Used to decide whether a newline-free reply needs the markdown renderer
+    // (and the source/rendered toggle) rather than being shown verbatim. Patterns are
+    // deliberately loose — a false positive just routes a plain sentence through the
+    // renderer (which produces identical output) and adds a toggle; a false negative is
+    // the actual bug (literal ** shown, no formatting). Emphasis alternatives require
+    // non-space, non-delimiter content so bare arithmetic like "a * b" doesn't count.
+    [GeneratedRegex(
+        @"\*\*[^*\n\s][^*\n]*\*\*"                 // **bold**
+        + @"|(?<!\*)\*[^*\n\s][^*\n]*\*(?!\*)"     // *italic*
+        + @"|(?<![\w_])__[^_\n\s][^_\n]*__(?![\w_])" // __bold__
+        + @"|(?<![\w_])_[^_\n\s][^_\n]*_(?![\w_])" // _italic_
+        + @"|`[^`\n]+`"                            // `code`
+        + @"|\[[^\]\n]+\]\([^)\n]+\)"              // [text](url)
+        + @"|https?://",                           // bare URL
+        RegexOptions.IgnoreCase)]
+    private static partial Regex InlineMarkdownRegex();
 
     [GeneratedRegex(@"^(\s*)(.*?)(\s*)$", RegexOptions.Singleline)]
     private static partial Regex TrimWsRegex();
@@ -48,8 +61,11 @@ public static partial class MarkdownHelper
 
     // Bare http/https URL. Stops at whitespace, quotes, brackets, and parens so the
     // generated [url](url) markdown stays well-formed; trailing sentence punctuation
-    // is trimmed separately (see TrimUrlTrailing).
-    [GeneratedRegex(@"\Ghttps?://[^\s<>""'`()\[\]{}|\\^]+", RegexOptions.IgnoreCase)]
+    // is trimmed separately (see TrimUrlTrailing). Asterisks are excluded too: a URL
+    // wrapped in bold (**https://x.com**) would otherwise swallow the closing ** into
+    // the match, leaving a stray leading ** that renders as literal stars. Asterisks
+    // are legal-but-rare in URLs and conventionally percent-encoded, so this is safe.
+    [GeneratedRegex(@"\Ghttps?://[^\s<>""'`()\[\]{}|\\^*]+", RegexOptions.IgnoreCase)]
     private static partial Regex UrlCandidateRegex();
 
     public const string FileLinkScheme = "agentdock-file";
@@ -73,27 +89,80 @@ public static partial class MarkdownHelper
     }
 
     /// <summary>
+    /// Returns true when <paramref name="text"/> should be handed to the markdown
+    /// renderer rather than shown verbatim. Multi-line text always qualifies (it may
+    /// carry lists, headings, tables, or code fences); single-line text qualifies only
+    /// when it contains an inline construct the renderer would change — emphasis, a code
+    /// span, a link, or a bare URL. A single-line plain sentence stays plain (no toggle).
+    /// </summary>
+    public static bool LooksLikeMarkdown(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return false;
+        return text.Contains('\n') || InlineMarkdownRegex().IsMatch(text);
+    }
+
+    /// <summary>
     /// Rewrites <c>**text `code` text**</c> as <c>**text** `code` **text**</c> so that
-    /// MdXaml can pair the bold delimiters. Also handles partial-link cases like
-    /// <c>**See [foo](url) more**</c>. Trims whitespace at split boundaries to satisfy
-    /// CommonMark flanking rules.
+    /// MdXaml can pair the bold delimiters. MdXaml parses code spans / links before bold,
+    /// so a <c>**</c> pair straddling one of those atoms is left orphaned and renders as
+    /// literal asterisks; splitting the bold around each atom lets every fragment pair.
+    /// Also handles partial-link cases like <c>**See [foo](url) more**</c>. Trims
+    /// whitespace at split boundaries to satisfy CommonMark flanking rules.
+    ///
+    /// Delimiters are paired left-to-right and non-overlapping — a <c>**</c> is matched
+    /// to the very next <c>**</c> on the same line, then scanning resumes past it. A pair
+    /// with no atom inside is emitted unchanged (MdXaml already renders plain bold), which
+    /// is what keeps a line like <c>**a**: `x` and **b**: `y`</c> intact: the closing
+    /// <c>**</c> of <c>a</c> can never bind to the opening <c>**</c> of <c>b</c> and wrap
+    /// the code span between two separate bolds. An unpaired <c>**</c> (next <c>**</c> is
+    /// on a later line, or absent) is emitted literally and scanning continues past it.
     /// </summary>
     private static string FixBoldAcrossInlineAtoms(string markdown)
     {
-        return BoldContainingInlineRegex().Replace(markdown, m =>
+        var sb = new StringBuilder(markdown.Length);
+        var i = 0;
+        while (i < markdown.Length)
         {
-            var inner = m.Groups[1].Value;
-            var sb = new StringBuilder();
-            var lastEnd = 0;
-            foreach (Match atom in InlineAtomRegex().Matches(inner))
+            var open = markdown.IndexOf("**", i, StringComparison.Ordinal);
+            if (open < 0)
             {
-                EmitBoldTextSegment(inner.Substring(lastEnd, atom.Index - lastEnd), sb);
-                sb.Append(atom.Value);
-                lastEnd = atom.Index + atom.Length;
+                sb.Append(markdown, i, markdown.Length - i);
+                break;
             }
-            EmitBoldTextSegment(inner.Substring(lastEnd), sb);
-            return sb.ToString();
-        });
+
+            var close = markdown.IndexOf("**", open + 2, StringComparison.Ordinal);
+            var newline = markdown.IndexOf('\n', open + 2);
+            if (close < 0 || (newline >= 0 && newline < close))
+            {
+                // Unpaired on this line — emit the ** literally and keep scanning.
+                sb.Append(markdown, i, open + 2 - i);
+                i = open + 2;
+                continue;
+            }
+
+            sb.Append(markdown, i, open - i);
+            var inner = markdown.Substring(open + 2, close - (open + 2));
+            if (InlineAtomRegex().IsMatch(inner))
+                sb.Append(SplitBoldAroundAtoms(inner));
+            else
+                sb.Append("**").Append(inner).Append("**");
+            i = close + 2;
+        }
+        return sb.ToString();
+    }
+
+    private static string SplitBoldAroundAtoms(string inner)
+    {
+        var sb = new StringBuilder();
+        var lastEnd = 0;
+        foreach (Match atom in InlineAtomRegex().Matches(inner))
+        {
+            EmitBoldTextSegment(inner.Substring(lastEnd, atom.Index - lastEnd), sb);
+            sb.Append(atom.Value);
+            lastEnd = atom.Index + atom.Length;
+        }
+        EmitBoldTextSegment(inner.Substring(lastEnd), sb);
+        return sb.ToString();
     }
 
     private static void EmitBoldTextSegment(string segment, StringBuilder sb)
@@ -183,7 +252,7 @@ public static partial class MarkdownHelper
 
             // Replace FlowDocument tables with WPF Grids — see ConvertTablesToGrids.
             // Runs AFTER WireLinks so any Hyperlinks inside table cells keep their
-            // wired RequestNavigate handlers when moved into the Grid.
+            // wired click handlers when moved into the per-cell RichTextBox.
             ConvertTablesToGrids(doc);
 
             // Detach from the temp viewer so the document can be re-parented to a
@@ -275,6 +344,17 @@ public static partial class MarkdownHelper
         for (var r = 0; r < rows.Count; r++)
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
 
+        // Logical text grid, captured in parallel with the visual cells so the table
+        // can be copied to the clipboard (TSV + HTML) — a BlockUIContainer's Grid is a
+        // UI island in the FlowDocument and contributes no selectable/copyable text, so
+        // a right-click "Copy table" is the only way to get this data into Excel etc.
+        var textGrid = new string[rows.Count][];
+        for (var r = 0; r < rows.Count; r++)
+        {
+            textGrid[r] = new string[columnCount];
+            Array.Fill(textGrid[r], "");
+        }
+
         for (var r = 0; r < rows.Count; r++)
         {
             var (row, isHeader) = rows[r];
@@ -283,7 +363,10 @@ public static partial class MarkdownHelper
             foreach (var cell in row.Cells)
             {
                 if (col >= columnCount) break;
-                var border = BuildCellBorder(cell, isHeader, isEvenRow);
+                // Read the cell's plain text before BuildCellBorder, which moves (and
+                // clears) the cell's inlines into a TextBlock.
+                if (col < columnCount) textGrid[r][col] = GetCellPlainText(cell);
+                var border = BuildCellBorder(cell, isHeader, isEvenRow, textGrid, foreground);
                 Grid.SetRow(border, r);
                 Grid.SetColumn(border, col);
                 var span = Math.Max(1, cell.ColumnSpan);
@@ -293,20 +376,122 @@ public static partial class MarkdownHelper
             }
         }
 
+        grid.ContextMenu = BuildTableContextMenu(textGrid);
         return grid;
     }
 
-    private static Border BuildCellBorder(TableCell cell, bool isHeader, bool isEvenRow)
+    // Right-click menu for a rendered table: copies the whole table to the clipboard.
+    private static ContextMenu BuildTableContextMenu(string[][] textGrid)
     {
-        var text = new TextBlock { TextWrapping = TextWrapping.Wrap };
-        if (isHeader) text.FontWeight = FontWeights.Bold;
-        PopulateCellTextBlock(cell, text);
+        var menu = new ContextMenu();
+        var copyItem = new MenuItem { Header = "Copy table" };
+        copyItem.Click += (_, _) => CopyTableToClipboard(textGrid);
+        menu.Items.Add(copyItem);
+        return menu;
+    }
 
+    // Concatenates a cell's block plain text, joining multiple blocks with a space so
+    // the result stays on one logical line (newlines inside a cell would break the
+    // TSV row/column grid Excel reconstructs).
+    private static string GetCellPlainText(TableCell cell)
+    {
+        var sb = new StringBuilder();
+        foreach (var block in cell.Blocks)
+        {
+            if (sb.Length > 0) sb.Append(' ');
+            sb.Append(GetBlockPlainText(block));
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Places a rendered table on the clipboard as tab-separated text (so Excel /
+    /// Sheets split it into columns on paste) and as an HTML table (so rich targets
+    /// like Word keep the grid). Tabs / newlines inside a cell are collapsed to spaces
+    /// so the column alignment survives.
+    /// </summary>
+    private static void CopyTableToClipboard(string[][] textGrid)
+    {
+        var tsv = new StringBuilder();
+        foreach (var row in textGrid)
+        {
+            for (var c = 0; c < row.Length; c++)
+            {
+                if (c > 0) tsv.Append('\t');
+                tsv.Append(CleanTsvCell(row[c]));
+            }
+            tsv.Append("\r\n");
+        }
+
+        var data = new DataObject();
+        data.SetData(DataFormats.UnicodeText, tsv.ToString());
+        data.SetData(DataFormats.Text, tsv.ToString());
+        data.SetData(DataFormats.Html, BuildHtmlClipboard(textGrid));
+
+        try
+        {
+            Clipboard.SetDataObject(data, copy: true);
+        }
+        catch (Exception ex)
+        {
+            // The clipboard can be transiently locked by another process; a failed copy
+            // shouldn't take down the chat.
+            Log.Error("Failed to copy table to clipboard", ex);
+        }
+    }
+
+    // Collapses the characters that define TSV structure (tab / CR / LF) to spaces so a
+    // multi-line or tab-containing cell can't shift the grid Excel parses.
+    private static string CleanTsvCell(string cell)
+        => cell.Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ');
+
+    // Builds a CF_HTML clipboard payload (the byte-offset header WPF/Windows require)
+    // wrapping an HTML <table> of the cell text.
+    private static string BuildHtmlClipboard(string[][] textGrid)
+    {
+        var body = new StringBuilder();
+        body.Append("<table border=\"1\" cellspacing=\"0\" cellpadding=\"4\">");
+        foreach (var row in textGrid)
+        {
+            body.Append("<tr>");
+            foreach (var cell in row)
+                body.Append("<td>").Append(System.Net.WebUtility.HtmlEncode(cell)).Append("</td>");
+            body.Append("</tr>");
+        }
+        body.Append("</table>");
+        return WrapCfHtml(body.ToString());
+    }
+
+    // Wraps an HTML fragment in the CF_HTML format: a header declaring UTF-8 byte
+    // offsets of the document and fragment, followed by the markup. Offsets are
+    // computed in bytes (UTF-8) per the spec; the header uses fixed-width 8-digit
+    // fields so its own length is constant and doesn't perturb the offsets.
+    private static string WrapCfHtml(string fragment)
+    {
+        const string header =
+            "Version:0.9\r\nStartHTML:{0:00000000}\r\nEndHTML:{1:00000000}\r\n"
+            + "StartFragment:{2:00000000}\r\nEndFragment:{3:00000000}\r\n";
+        const string preFragment = "<html><body>\r\n<!--StartFragment-->";
+        const string postFragment = "<!--EndFragment-->\r\n</body></html>";
+
+        var utf8 = Encoding.UTF8;
+        var headerLen = utf8.GetByteCount(string.Format(header, 0, 0, 0, 0));
+        var startHtml = headerLen;
+        var startFragment = startHtml + utf8.GetByteCount(preFragment);
+        var endFragment = startFragment + utf8.GetByteCount(fragment);
+        var endHtml = endFragment + utf8.GetByteCount(postFragment);
+
+        return string.Format(header, startHtml, endHtml, startFragment, endFragment)
+            + preFragment + fragment + postFragment;
+    }
+
+    private static Border BuildCellBorder(TableCell cell, bool isHeader, bool isEvenRow, string[][] textGrid, Brush foreground)
+    {
         var border = new Border
         {
             BorderThickness = new Thickness(0.5),
             Padding = new Thickness(13, 6, 13, 6),
-            Child = text,
+            Child = BuildCellContent(cell, isHeader, textGrid, foreground),
         };
         border.SetResourceReference(Border.BorderBrushProperty, "MarkdownTableBorderBrush");
         if (isHeader)
@@ -318,21 +503,74 @@ public static partial class MarkdownHelper
     }
 
     /// <summary>
-    /// Moves the inline content of a table cell's paragraphs into <paramref name="tb"/>.
+    /// Builds the selectable content for one table cell. A read-only, chrome-less
+    /// <see cref="RichTextBox"/> is used rather than a <see cref="TextBlock"/> so cell
+    /// text can be highlighted and copied with the mouse — a TextBlock renders text but
+    /// exposes no selection, which is why table text was previously uncopyable. Read-only
+    /// keeps wired Hyperlinks single-click clickable while still allowing selection, and
+    /// re-parenting the cell's inlines (rather than flattening to plain text) preserves
+    /// bold/italic/code formatting. The whole grid is still a UI island in the outer
+    /// FlowDocument (the document-wide selection can't reach into it), so the cell's
+    /// context menu also offers "Copy table" for a whole-table copy.
+    /// </summary>
+    private static RichTextBox BuildCellContent(TableCell cell, bool isHeader, string[][] textGrid, Brush foreground)
+    {
+        var paragraph = new Paragraph { Margin = new Thickness(0) };
+        if (isHeader) paragraph.FontWeight = FontWeights.Bold;
+        PopulateCellParagraph(cell, paragraph);
+
+        return new RichTextBox
+        {
+            Document = new FlowDocument(paragraph) { PagePadding = new Thickness(0) },
+            IsReadOnly = true,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            // Set the theme foreground explicitly rather than relying on the grid's
+            // inherited TextElement.Foreground: the default RichTextBox style carries a
+            // Foreground setter (system text brush, ~black), and a style-setter value
+            // outranks inheritance — so without this the cell text renders black-on-dark
+            // and is unreadable in every dark theme. A local value beats the style setter.
+            Foreground = foreground,
+            Padding = new Thickness(0),
+            FocusVisualStyle = null,
+            IsTabStop = false,
+            IsReadOnlyCaretVisible = false,
+            // Vertical hidden + horizontal disabled: the box grows to fit its content and
+            // wraps long text to the column width instead of scrolling within the cell.
+            VerticalScrollBarVisibility = ScrollBarVisibility.Hidden,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            ContextMenu = BuildCellContextMenu(textGrid),
+        };
+    }
+
+    // Right-click menu for a table cell: "Copy" (the current selection, via the standard
+    // editing command routed to the focused RichTextBox) and "Copy table" (the whole grid).
+    private static ContextMenu BuildCellContextMenu(string[][] textGrid)
+    {
+        var menu = new ContextMenu();
+        menu.Items.Add(new MenuItem { Header = "Copy", Command = ApplicationCommands.Copy });
+        var copyTable = new MenuItem { Header = "Copy table" };
+        copyTable.Click += (_, _) => CopyTableToClipboard(textGrid);
+        menu.Items.Add(copyTable);
+        return menu;
+    }
+
+    /// <summary>
+    /// Moves the inline content of a table cell's paragraphs into <paramref name="target"/>.
     /// Inlines are re-parented (cleared from their paragraph first) so existing formatting
     /// and wired hyperlink handlers survive the move. Non-paragraph blocks are flattened to
     /// plain text — GFM cells are inline-only, so that path is a defensive fallback.
     /// </summary>
-    private static void PopulateCellTextBlock(TableCell cell, TextBlock tb)
+    private static void PopulateCellParagraph(TableCell cell, Paragraph target)
     {
         var first = true;
-        // Snapshot first: moving a paragraph's inlines into the TextBlock mutates the
+        // Snapshot first: moving a paragraph's inlines into the target mutates the source
         // FlowDocument's shared TextContainer (p.Inlines.Clear below), which bumps the
         // generation that a live cell.Blocks enumerator validates against — otherwise the
         // next iteration throws "Collection was modified". Same reason p.Inlines is ToList'd.
         foreach (var block in cell.Blocks.ToList())
         {
-            if (!first) tb.Inlines.Add(new LineBreak());
+            if (!first) target.Inlines.Add(new LineBreak());
             first = false;
 
             if (block is Paragraph p)
@@ -343,17 +581,17 @@ public static partial class MarkdownHelper
                 {
                     if (inl is Hyperlink h)
                     {
-                        // FlowDocument-scoped implicit styles don't reach a Hyperlink once
-                        // it's hosted in a TextBlock, so apply the link look explicitly.
+                        // The cell's new FlowDocument carries none of the outer document's
+                        // implicit styles, so apply the link look explicitly.
                         h.TextDecorations = null;
                         h.SetResourceReference(Hyperlink.ForegroundProperty, "MarkdownLinkForeground");
                     }
-                    tb.Inlines.Add(inl);
+                    target.Inlines.Add(inl);
                 }
             }
             else
             {
-                tb.Inlines.Add(new Run(GetBlockPlainText(block)));
+                target.Inlines.Add(new Run(GetBlockPlainText(block)));
             }
         }
     }
@@ -554,9 +792,21 @@ public static partial class MarkdownHelper
         if (doc == null) return;
         foreach (var link in EnumerateHyperlinks(doc))
         {
-            if (link.NavigateUri == null) continue;
+            // MdXaml does NOT set NavigateUri on the hyperlinks it generates. It stores the
+            // target in CommandParameter and sets Command = NavigationCommands.GoToPage. We
+            // host the built document by assigning FlowDocumentScrollViewer.Document directly
+            // (not MarkdownScrollViewer.Markdown), so MdXaml never installs a CommandBinding
+            // for GoToPage — that command's CanExecute is therefore false, which DISABLES the
+            // Hyperlink. It renders as a link but swallows every click. Recover the URL, drop
+            // the dead command to re-enable the link, and drive navigation from Click (which,
+            // unlike RequestNavigate, doesn't depend on NavigateUri being set).
+            var url = link.CommandParameter as string ?? link.NavigateUri?.OriginalString;
+            if (string.IsNullOrEmpty(url)) continue;
 
-            var abs = FromFileLinkUri(link.NavigateUri.OriginalString);
+            link.Command = null;
+            link.CommandParameter = null;
+
+            var abs = FromFileLinkUri(url);
             if (abs != null)
             {
                 if (onFileClick == null) continue;
@@ -565,27 +815,18 @@ public static partial class MarkdownHelper
                 // monospace look here — file references read as code.
                 link.FontFamily = CodeFontFamily;
                 link.Cursor = Cursors.Hand;
-                link.RequestNavigate += (_, e) =>
-                {
-                    e.Handled = true;
-                    onFileClick(abs);
-                };
+                link.Click += (_, _) => onFileClick(abs);
                 continue;
             }
 
-            var uri = link.NavigateUri;
-            if (uri.IsAbsoluteUri
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri)
                 && (uri.Scheme == Uri.UriSchemeHttp
                     || uri.Scheme == Uri.UriSchemeHttps
                     || uri.Scheme == Uri.UriSchemeMailto))
             {
                 var target = uri.AbsoluteUri;
                 link.Cursor = Cursors.Hand;
-                link.RequestNavigate += (_, e) =>
-                {
-                    e.Handled = true;
-                    OpenInBrowser(target);
-                };
+                link.Click += (_, _) => OpenInBrowser(target);
             }
         }
     }

--- a/src/AgentDock/Services/SendQueue.cs
+++ b/src/AgentDock/Services/SendQueue.cs
@@ -1,0 +1,103 @@
+using System.Collections.ObjectModel;
+using AgentDock.Models;
+
+namespace AgentDock.Services;
+
+/// <summary>
+/// A chat's outbox: an ordered list of messages waiting to be sent to Claude. This is
+/// the pure ordering/timing core — no WPF, no timers, no dispatch. The
+/// <c>AiChatControl</c> owns the timer that ticks it, the session-idle check, and the
+/// actual send + bubble creation; keeping the rules here makes them unit-testable
+/// (see <c>SendQueueTests</c>).
+///
+/// <para><b>Semantics — strict FIFO.</b> Only the head is ever eligible. The head is
+/// dispatchable when the session is idle (caller's responsibility) and its
+/// <see cref="QueuedMessage.NotBeforeUtc"/> — if any — has passed. A not-yet-due
+/// scheduled item therefore holds everything behind it: insertion order is execution
+/// order. That is what makes "schedule A for later, then queue B behind it" run A then
+/// B, rather than letting B jump ahead.</para>
+///
+/// <para><see cref="Items"/> is an <see cref="ObservableCollection{T}"/> so the queue
+/// panel can bind to it directly; mutate only on the UI thread (all callers do).</para>
+/// </summary>
+public sealed class SendQueue
+{
+    public ObservableCollection<QueuedMessage> Items { get; } = [];
+
+    public int Count => Items.Count;
+    public bool IsEmpty => Items.Count == 0;
+
+    /// <summary>Raised whenever the queue's contents change (enqueue / remove / clear /
+    /// dequeue) so the host can refresh panel visibility and the tab-strip indicator.</summary>
+    public event Action? Changed;
+
+    public void Enqueue(QueuedMessage message)
+    {
+        Items.Add(message);
+        Changed?.Invoke();
+    }
+
+    public bool Remove(Guid id)
+    {
+        var index = IndexOf(id);
+        if (index < 0) return false;
+        Items.RemoveAt(index);
+        Changed?.Invoke();
+        return true;
+    }
+
+    public void Clear()
+    {
+        if (Items.Count == 0) return;
+        Items.Clear();
+        Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Returns the head message if it is ready to dispatch at <paramref name="nowUtc"/>
+    /// (no time gate, or the gate has passed), else null. Does NOT check session state
+    /// and does NOT remove the item — the caller verifies the session is idle and then
+    /// calls <see cref="DequeueHead"/> once it has actually dispatched.
+    /// </summary>
+    public QueuedMessage? PeekReady(DateTime nowUtc)
+    {
+        if (Items.Count == 0) return null;
+        var head = Items[0];
+        if (head.NotBeforeUtc is DateTime fireAt && nowUtc < fireAt) return null;
+        return head;
+    }
+
+    /// <summary>Removes and returns the head, or null when empty.</summary>
+    public QueuedMessage? DequeueHead()
+    {
+        if (Items.Count == 0) return null;
+        var head = Items[0];
+        Items.RemoveAt(0);
+        Changed?.Invoke();
+        return head;
+    }
+
+    /// <summary>
+    /// The earliest future scheduled fire time in the queue, or null when nothing is
+    /// time-gated in the future. Drives the tab-strip clock glyph (a scheduled item is
+    /// the only thing that persists at idle — plain queued items drain immediately).
+    /// </summary>
+    public DateTime? NextScheduledFireUtc
+    {
+        get
+        {
+            DateTime? earliest = null;
+            foreach (var m in Items)
+                if (m.NotBeforeUtc is DateTime t && (earliest is null || t < earliest))
+                    earliest = t;
+            return earliest;
+        }
+    }
+
+    private int IndexOf(Guid id)
+    {
+        for (var i = 0; i < Items.Count; i++)
+            if (Items[i].Id == id) return i;
+        return -1;
+    }
+}

--- a/src/AgentDock/Themes/EmberTheme.xaml
+++ b/src/AgentDock/Themes/EmberTheme.xaml
@@ -34,6 +34,7 @@
     <SolidColorBrush x:Key="TabIconIdleForeground" Color="#8BBF65" />
     <SolidColorBrush x:Key="TabIconWorkingForeground" Color="#D4854A" />
     <SolidColorBrush x:Key="TabIconWaitingForeground" Color="#E6A96F" />
+    <SolidColorBrush x:Key="TabIconScheduledForeground" Color="#5FB8C4" />
     <SolidColorBrush x:Key="TabIconErrorForeground" Color="#E06B5A" />
 
     <!-- File preview -->

--- a/src/AgentDock/Themes/FrostTheme.xaml
+++ b/src/AgentDock/Themes/FrostTheme.xaml
@@ -34,6 +34,7 @@
     <SolidColorBrush x:Key="TabIconIdleForeground" Color="#1A8A5C" />
     <SolidColorBrush x:Key="TabIconWorkingForeground" Color="#2060B0" />
     <SolidColorBrush x:Key="TabIconWaitingForeground" Color="#D08B20" />
+    <SolidColorBrush x:Key="TabIconScheduledForeground" Color="#0E8AA0" />
     <SolidColorBrush x:Key="TabIconErrorForeground" Color="#D03030" />
 
     <!-- File preview -->

--- a/src/AgentDock/Themes/MidnightTheme.xaml
+++ b/src/AgentDock/Themes/MidnightTheme.xaml
@@ -34,6 +34,7 @@
     <SolidColorBrush x:Key="TabIconIdleForeground" Color="#56D4A0" />
     <SolidColorBrush x:Key="TabIconWorkingForeground" Color="#58A6FF" />
     <SolidColorBrush x:Key="TabIconWaitingForeground" Color="#E3B341" />
+    <SolidColorBrush x:Key="TabIconScheduledForeground" Color="#22C7D6" />
     <SolidColorBrush x:Key="TabIconErrorForeground" Color="#F85149" />
 
     <!-- File preview -->

--- a/src/AgentDock/Themes/ObsidianTheme.xaml
+++ b/src/AgentDock/Themes/ObsidianTheme.xaml
@@ -34,6 +34,7 @@
     <SolidColorBrush x:Key="TabIconIdleForeground" Color="#4EC9B0" />
     <SolidColorBrush x:Key="TabIconWorkingForeground" Color="#569CD6" />
     <SolidColorBrush x:Key="TabIconWaitingForeground" Color="#FFB347" />
+    <SolidColorBrush x:Key="TabIconScheduledForeground" Color="#3DBFD9" />
     <SolidColorBrush x:Key="TabIconErrorForeground" Color="#FF6B6B" />
 
     <!-- File preview -->

--- a/src/AgentDock/Themes/ParchmentTheme.xaml
+++ b/src/AgentDock/Themes/ParchmentTheme.xaml
@@ -34,6 +34,7 @@
     <SolidColorBrush x:Key="TabIconIdleForeground" Color="#3A7A30" />
     <SolidColorBrush x:Key="TabIconWorkingForeground" Color="#8B6914" />
     <SolidColorBrush x:Key="TabIconWaitingForeground" Color="#B88020" />
+    <SolidColorBrush x:Key="TabIconScheduledForeground" Color="#1F7A8C" />
     <SolidColorBrush x:Key="TabIconErrorForeground" Color="#C44030" />
 
     <!-- File preview -->

--- a/src/AgentDock/Themes/SakuraTheme.xaml
+++ b/src/AgentDock/Themes/SakuraTheme.xaml
@@ -34,6 +34,7 @@
     <SolidColorBrush x:Key="TabIconIdleForeground" Color="#3A8A50" />
     <SolidColorBrush x:Key="TabIconWorkingForeground" Color="#D4477A" />
     <SolidColorBrush x:Key="TabIconWaitingForeground" Color="#C08030" />
+    <SolidColorBrush x:Key="TabIconScheduledForeground" Color="#2C8A99" />
     <SolidColorBrush x:Key="TabIconErrorForeground" Color="#D03030" />
 
     <!-- File preview -->

--- a/src/AgentDock/Windows/ImagePreviewDialog.xaml
+++ b/src/AgentDock/Windows/ImagePreviewDialog.xaml
@@ -1,0 +1,140 @@
+<Window x:Class="AgentDock.Windows.ImagePreviewDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Image"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Icon="/Assets/agentdock.png"
+        Background="Transparent">
+
+    <Window.Resources>
+        <Style x:Key="DialogButton" TargetType="{x:Type Button}">
+            <Setter Property="MinWidth" Value="76" />
+            <Setter Property="Height" Value="28" />
+            <Setter Property="Padding" Value="12,0" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Foreground" Value="{DynamicResource HelpForeground}" />
+            <Setter Property="Background" Value="{DynamicResource HelpCardBackground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource HelpCardBorderBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Border x:Name="Bd"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background"
+                                        Value="{DynamicResource MenuHighlightBackground}" />
+                            </Trigger>
+                            <Trigger Property="IsDefault" Value="True">
+                                <Setter TargetName="Bd" Property="BorderBrush"
+                                        Value="{DynamicResource TabButtonActiveBorderBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource HelpBackground}"
+            BorderBrush="{DynamicResource ToolbarBorderBrush}"
+            BorderThickness="1"
+            CornerRadius="4">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" /> <!-- Title bar -->
+                <RowDefinition Height="Auto" /> <!-- Image -->
+                <RowDefinition Height="Auto" /> <!-- Buttons -->
+            </Grid.RowDefinitions>
+
+            <!-- Mini title bar -->
+            <Border Grid.Row="0"
+                    Background="{DynamicResource TitleBarBackground}"
+                    CornerRadius="4,4,0,0"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <Grid>
+                    <TextBlock x:Name="TitleText"
+                               Text="Image"
+                               FontSize="12"
+                               FontWeight="SemiBold"
+                               VerticalAlignment="Center"
+                               Margin="12,8"
+                               TextTrimming="CharacterEllipsis"
+                               MaxWidth="760"
+                               HorizontalAlignment="Left"
+                               Foreground="{DynamicResource TitleBarForeground}" />
+                    <Button HorizontalAlignment="Right"
+                            VerticalAlignment="Stretch"
+                            Width="42"
+                            Cursor="Hand"
+                            ToolTip="Close"
+                            Foreground="{DynamicResource TitleBarForeground}"
+                            Click="CloseButton_Click">
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <Border x:Name="Bd" Background="Transparent" CornerRadius="0,4,0,0">
+                                    <TextBlock x:Name="Glyph"
+                                               Text="&#xE8BB;"
+                                               FontFamily="Segoe MDL2 Assets"
+                                               FontSize="10"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               Foreground="{TemplateBinding Foreground}" />
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter TargetName="Bd" Property="Background" Value="#E81123" />
+                                        <Setter TargetName="Glyph" Property="Foreground" Value="White" />
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
+                </Grid>
+            </Border>
+
+            <!-- Image -->
+            <Border Grid.Row="1" Margin="16,16,16,8"
+                    Background="{DynamicResource HelpCardBackground}"
+                    BorderBrush="{DynamicResource HelpCardBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="3">
+                <Image x:Name="PreviewImage"
+                       MaxWidth="900" MaxHeight="640"
+                       Stretch="Uniform"
+                       SnapsToDevicePixels="True"
+                       Margin="4" />
+            </Border>
+
+            <!-- Buttons -->
+            <StackPanel Grid.Row="2"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Margin="16,8,16,16">
+                <Button Content="Remove"
+                        Style="{StaticResource DialogButton}"
+                        Foreground="{DynamicResource ChatDangerForeground}"
+                        Click="RemoveButton_Click"
+                        Margin="0,0,8,0" />
+                <Button Content="Close"
+                        Style="{StaticResource DialogButton}"
+                        IsDefault="True"
+                        IsCancel="True"
+                        Click="CloseButton_Click" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/src/AgentDock/Windows/ImagePreviewDialog.xaml.cs
+++ b/src/AgentDock/Windows/ImagePreviewDialog.xaml.cs
@@ -1,0 +1,45 @@
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace AgentDock.Windows;
+
+/// <summary>
+/// Lightbox for a queued image attachment: shows it larger than the input-area
+/// chip, with a Remove button. <see cref="Show"/> returns true if the user asked
+/// to remove the image (Gmail-style: click the thumbnail to enlarge, remove from
+/// there).
+/// </summary>
+public partial class ImagePreviewDialog : Window
+{
+    /// <summary>True when the user clicked Remove.</summary>
+    public bool RemoveRequested { get; private set; }
+
+    private ImagePreviewDialog()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Shows the preview. Returns true if the user clicked Remove, false otherwise.
+    /// </summary>
+    public static bool Show(Window owner, ImageSource image, string title)
+    {
+        var dialog = new ImagePreviewDialog { Owner = owner };
+        dialog.PreviewImage.Source = image;
+        dialog.Title = title;
+        dialog.TitleText.Text = title;
+        dialog.ShowDialog();
+        return dialog.RemoveRequested;
+    }
+
+    private void RemoveButton_Click(object sender, RoutedEventArgs e)
+    {
+        RemoveRequested = true;
+        DialogResult = false;
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => DialogResult = false;
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e) => DragMove();
+}

--- a/src/AgentDock/Windows/ScheduleMessageDialog.xaml
+++ b/src/AgentDock/Windows/ScheduleMessageDialog.xaml
@@ -130,13 +130,16 @@
                         CornerRadius="3">
                     <ScrollViewer MaxHeight="120" VerticalScrollBarVisibility="Auto">
                         <TextBox x:Name="MessagePreview"
-                                 IsReadOnly="True"
                                  BorderThickness="0"
                                  Background="Transparent"
                                  Foreground="{DynamicResource HelpForeground}"
+                                 CaretBrush="{DynamicResource HelpForeground}"
                                  FontFamily="Cascadia Code, Consolas, Courier New"
                                  FontSize="12"
                                  TextWrapping="Wrap"
+                                 AcceptsReturn="True"
+                                 MinHeight="48"
+                                 VerticalContentAlignment="Top"
                                  Padding="8,6" />
                     </ScrollViewer>
                 </Border>

--- a/src/AgentDock/Windows/ScheduleMessageDialog.xaml.cs
+++ b/src/AgentDock/Windows/ScheduleMessageDialog.xaml.cs
@@ -21,6 +21,9 @@ public partial class ScheduleMessageDialog : Window
     /// <summary>The chosen delay when the user clicks Schedule in compose mode.</summary>
     public TimeSpan Delay { get; private set; }
 
+    /// <summary>The (possibly edited) message when the user clicks Schedule in compose mode.</summary>
+    public string MessageText { get; private set; } = "";
+
     /// <summary>True when the user clicked "Cancel Schedule" in manage mode.</summary>
     public bool CancelRequested { get; private set; }
 
@@ -33,21 +36,32 @@ public partial class ScheduleMessageDialog : Window
     }
 
     /// <summary>
-    /// Shows the compose dialog. Returns the chosen delay, or null if cancelled.
+    /// Shows the compose dialog, seeded with the current draft (which may be empty —
+    /// the message is editable here, so scheduling can start from an empty input box).
+    /// Returns the composed message and chosen delay, or null if cancelled.
     /// </summary>
-    public static TimeSpan? ShowCompose(Window owner, string messageText)
+    public static (string message, TimeSpan delay)? ShowCompose(Window owner, string draft)
     {
         var dialog = new ScheduleMessageDialog { Owner = owner };
-        dialog.MessagePreview.Text = messageText;
+        dialog.MessagePreview.Text = draft;
         dialog.HoursBox.Text = "1";
         dialog.MinutesBox.Text = "0";
         dialog.UpdateComposeHint();
         dialog.Loaded += (_, _) =>
         {
-            dialog.HoursBox.Focus();
-            dialog.HoursBox.SelectAll();
+            // No draft yet → let the user type the message first; otherwise jump
+            // straight to the delay so they can just pick a time and go.
+            if (string.IsNullOrEmpty(draft))
+            {
+                dialog.MessagePreview.Focus();
+            }
+            else
+            {
+                dialog.HoursBox.Focus();
+                dialog.HoursBox.SelectAll();
+            }
         };
-        return dialog.ShowDialog() == true ? dialog.Delay : null;
+        return dialog.ShowDialog() == true ? (dialog.MessageText, dialog.Delay) : null;
     }
 
     /// <summary>
@@ -118,6 +132,13 @@ public partial class ScheduleMessageDialog : Window
 
     private void ScheduleButton_Click(object sender, RoutedEventArgs e)
     {
+        var message = MessagePreview.Text.Trim();
+        if (string.IsNullOrEmpty(message))
+        {
+            ComposeHint.Text = "Type a message to schedule.";
+            MessagePreview.Focus();
+            return;
+        }
         var (hours, minutes) = ParseDuration();
         var total = new TimeSpan(hours, minutes, 0);
         if (total <= TimeSpan.Zero)
@@ -126,6 +147,7 @@ public partial class ScheduleMessageDialog : Window
             HoursBox.Focus();
             return;
         }
+        MessageText = message;
         Delay = total;
         DialogResult = true;
     }

--- a/tests/AgentDock.Tests/LinkifyPathsTests.cs
+++ b/tests/AgentDock.Tests/LinkifyPathsTests.cs
@@ -45,6 +45,15 @@ public class LinkifyPathsTests : IDisposable
             "See [https://example.com](https://example.com) here",
             MarkdownHelper.LinkifyPaths("See https://example.com here", _root));
 
+    // A bold-wrapped bare URL: the match must STOP at the closing ** rather than
+    // swallowing the asterisks into the URL. Otherwise PreProcess can't pair the
+    // bold and the leading ** renders as literal stars.
+    [Fact]
+    public void Linkify_BoldWrappedUrl_StopsAtClosingDelimiters()
+        => Assert.Equal(
+            "**[https://resend.com](https://resend.com)** — sign up",
+            MarkdownHelper.LinkifyPaths("**https://resend.com** — sign up", _root));
+
     [Fact]
     public void Linkify_LeavesExistingMarkdownLinkAlone()
     {
@@ -107,5 +116,16 @@ public class LinkifyPathsTests : IDisposable
             MarkdownHelper.LinkifyPaths("**[docs](https://x.com)** and docs/permission_groups.cs", _root));
         Assert.Contains("[**docs**](https://x.com)", pipeline);                       // bold moved inside label
         Assert.Contains(@"[docs/permission\_groups.cs](agentdock-file:///", pipeline); // path linkified + escaped
+    }
+
+    // Regression: a bare URL wrapped in bold must end up as a bold hyperlink, not a
+    // stray ** + broken link. Linkify stops the URL at the ** (see UrlCandidateRegex),
+    // then PreProcess's BoldLinkRegex moves the bold inside the label.
+    [Fact]
+    public void Pipeline_BoldWrappedUrl_BecomesBoldLink()
+    {
+        var pipeline = MarkdownHelper.PreProcess(
+            MarkdownHelper.LinkifyPaths("**https://resend.com** — sign up there", _root));
+        Assert.Equal("[**https://resend.com**](https://resend.com) — sign up there", pipeline);
     }
 }

--- a/tests/AgentDock.Tests/MarkdownPreProcessTests.cs
+++ b/tests/AgentDock.Tests/MarkdownPreProcessTests.cs
@@ -59,6 +59,54 @@ public class MarkdownPreProcessTests
     public void PreProcess_LeavesPlainBoldAndCodeUntouched(string input)
         => Assert.Equal(input, MarkdownHelper.PreProcess(input));
 
+    // Regression: two separate bolds, each followed by a code span, on one line. The
+    // closing ** of the first bold must NOT pair with the opening ** of the second and
+    // wrap the code span between them. MdXaml already renders these correctly on its own,
+    // so PreProcess must leave them untouched. Previously the splitter mis-paired the
+    // delimiters, producing "**a**:** `x` **and** b**: `y`" — a stray literal **.
+    [Theory]
+    [InlineData("**iac-aws**: `a` and **gcp**: `b`")]
+    [InlineData("**a**: `x`. **b**: `y`")]
+    [InlineData("**iac-aws**: `public-api-runs`")]                 // single bold, code outside it
+    [InlineData("**one** then `code` then **two**")]
+    public void PreProcess_DoesNotMisPairAdjacentBoldsAroundCode(string input)
+        => Assert.Equal(input, MarkdownHelper.PreProcess(input));
+
+    // The same hazard, but with a markdown link as the atom between two bolds (the shape
+    // LinkifyPaths produces from a bare file path sitting between two bold words).
+    [Fact]
+    public void PreProcess_DoesNotMisPairAdjacentBoldsAroundLink()
+        => Assert.Equal(
+            "**foo**: [src/x.cs](u) and **bar**: done",
+            MarkdownHelper.PreProcess("**foo**: [src/x.cs](u) and **bar**: done"));
+
+    // --- LooksLikeMarkdown: does a reply need the renderer + source/rendered toggle? ---
+    // Regression: a single-line reply carrying inline markdown was shown verbatim (literal
+    // ** stars, no formatting) with no toggle, because the old check was text.Contains('\n').
+
+    [Theory]
+    // The reported case: bold-wrapped URL + bold word + italic phrase, all on one line.
+    [InlineData("**https://keikaku.ai/docs/how-it-runs** — confirmed **live** (HTTP 200). Linked under *Getting started*.")]
+    [InlineData("this is **bold** text")]
+    [InlineData("this is *italic* text")]
+    [InlineData("this is _italic_ text")]
+    [InlineData("this is __bold__ text")]
+    [InlineData("run `git status` first")]
+    [InlineData("see [the docs](https://example.com) for more")]
+    [InlineData("visit https://example.com today")]
+    [InlineData("line one\nline two")]                       // multi-line always qualifies
+    public void LooksLikeMarkdown_TrueForInlineOrMultilineMarkdown(string input)
+        => Assert.True(MarkdownHelper.LooksLikeMarkdown(input));
+
+    [Theory]
+    [InlineData("just a plain sentence with no markup.")]
+    [InlineData("Done.")]
+    [InlineData("")]
+    [InlineData("2 * 3 = 6 and 4 * 5 = 20")]                 // bare arithmetic, not emphasis
+    [InlineData("snake_case_identifier stays plain")]        // underscores inside a word
+    public void LooksLikeMarkdown_FalseForPlainSingleLine(string input)
+        => Assert.False(MarkdownHelper.LooksLikeMarkdown(input));
+
     // --- StripLeadingVersionHeading: drop a leading "# vX.Y.Z" + blank line ---
 
     [Theory]

--- a/tests/AgentDock.Tests/RemoteWebUrlTests.cs
+++ b/tests/AgentDock.Tests/RemoteWebUrlTests.cs
@@ -1,0 +1,52 @@
+using AgentDock.Services;
+using Xunit;
+
+namespace AgentDock.Tests;
+
+/// <summary>
+/// Tests for <see cref="GitService.ToWebUrl"/> — the pure mapping from a git remote
+/// URL to a browsable https web URL (or null when the remote isn't a web host).
+///
+/// HOW TO ADD A CASE: if a real remote produces the wrong button URL (or a button
+/// where there shouldn't be one), add the raw remote string + expected result here.
+/// </summary>
+public class RemoteWebUrlTests
+{
+    [Theory]
+    // GitHub — https and SSH, with and without .git
+    [InlineData("https://github.com/develorem/agent-dock.git", "https://github.com/develorem/agent-dock")]
+    [InlineData("https://github.com/develorem/agent-dock", "https://github.com/develorem/agent-dock")]
+    [InlineData("git@github.com:develorem/agent-dock.git", "https://github.com/develorem/agent-dock")]
+    [InlineData("ssh://git@github.com/develorem/agent-dock.git", "https://github.com/develorem/agent-dock")]
+    // GitLab / Bitbucket / Codeberg
+    [InlineData("git@gitlab.com:group/sub/proj.git", "https://gitlab.com/group/sub/proj")]
+    [InlineData("https://bitbucket.org/team/repo.git", "https://bitbucket.org/team/repo")]
+    [InlineData("git@codeberg.org:user/repo.git", "https://codeberg.org/user/repo")]
+    // Self-hosted GitHub Enterprise / GitLab (host substring heuristic) over SSH
+    [InlineData("git@gitlab.mycorp.com:team/repo.git", "https://gitlab.mycorp.com/team/repo")]
+    [InlineData("git@github.internal.example:team/repo.git", "https://github.internal.example/team/repo")]
+    // Embedded credentials in an https URL are stripped
+    [InlineData("https://user:token@github.com/o/r.git", "https://github.com/o/r")]
+    // Azure DevOps — https passthrough and the distinct SSH path shape
+    [InlineData("https://dev.azure.com/org/project/_git/repo", "https://dev.azure.com/org/project/_git/repo")]
+    [InlineData("git@ssh.dev.azure.com:v3/org/project/repo", "https://dev.azure.com/org/project/_git/repo")]
+    public void ToWebUrl_MapsRecognizedRemotes(string remote, string expected)
+    {
+        Assert.Equal(expected, GitService.ToWebUrl(remote));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    // Plain SSH git server — a host, not a web page → no button
+    [InlineData("git@my-git-server.example:repos/thing.git")]
+    [InlineData("ssh://git@internal-host/srv/git/thing.git")]
+    // Local / file remotes
+    [InlineData("/srv/git/thing.git")]
+    [InlineData("file:///srv/git/thing.git")]
+    public void ToWebUrl_ReturnsNullForNonWebRemotes(string? remote)
+    {
+        Assert.Null(GitService.ToWebUrl(remote));
+    }
+}

--- a/tests/AgentDock.Tests/SendQueueTests.cs
+++ b/tests/AgentDock.Tests/SendQueueTests.cs
@@ -1,0 +1,177 @@
+using AgentDock.Models;
+using AgentDock.Services;
+using Xunit;
+
+namespace AgentDock.Tests;
+
+/// <summary>
+/// Tests for <see cref="SendQueue"/> — the pure ordering/timing core of the chat
+/// outbox. Covers strict-FIFO dispatch eligibility (<see cref="SendQueue.PeekReady"/>),
+/// time-gated (scheduled) items, and the tab-strip clock feed.
+///
+/// HOW TO ADD A CASE: if the queue dispatches in the wrong order or at the wrong time,
+/// reproduce it here with fixed UTC times (never DateTime.UtcNow — keep it deterministic).
+/// </summary>
+public class SendQueueTests
+{
+    private static readonly DateTime T0 = new(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    private static QueuedMessage Msg(string text, DateTime? notBefore = null)
+        => new() { Text = text, NotBeforeUtc = notBefore };
+
+    [Fact]
+    public void PeekReady_EmptyQueue_ReturnsNull()
+    {
+        var q = new SendQueue();
+        Assert.Null(q.PeekReady(T0));
+    }
+
+    [Fact]
+    public void PeekReady_PlainMessage_IsImmediatelyReady()
+    {
+        var q = new SendQueue();
+        q.Enqueue(Msg("a"));
+        Assert.Equal("a", q.PeekReady(T0)?.Text);
+    }
+
+    [Fact]
+    public void PeekReady_ScheduledInFuture_NotReadyUntilDue()
+    {
+        var q = new SendQueue();
+        q.Enqueue(Msg("later", T0.AddMinutes(10)));
+
+        Assert.Null(q.PeekReady(T0));                       // before fire time
+        Assert.Null(q.PeekReady(T0.AddMinutes(9)));         // still before
+        Assert.Equal("later", q.PeekReady(T0.AddMinutes(10))?.Text); // exactly due
+        Assert.Equal("later", q.PeekReady(T0.AddMinutes(11))?.Text); // past due
+    }
+
+    [Fact]
+    public void PeekReady_StrictFifo_NotYetDueHeadBlocksImmediateItemBehindIt()
+    {
+        var q = new SendQueue();
+        q.Enqueue(Msg("scheduled", T0.AddHours(1))); // head: not due for an hour
+        q.Enqueue(Msg("queued"));                    // behind it: no time gate
+
+        // The plain "queued" message must NOT jump ahead — the head gates everything.
+        Assert.Null(q.PeekReady(T0));
+
+        // Once the head is due, it's the one that dispatches first.
+        Assert.Equal("scheduled", q.PeekReady(T0.AddHours(1))?.Text);
+    }
+
+    [Fact]
+    public void DequeueHead_PopsInInsertionOrder()
+    {
+        var q = new SendQueue();
+        q.Enqueue(Msg("first"));
+        q.Enqueue(Msg("second"));
+
+        Assert.Equal("first", q.DequeueHead()?.Text);
+        Assert.Equal("second", q.DequeueHead()?.Text);
+        Assert.Null(q.DequeueHead());
+        Assert.True(q.IsEmpty);
+    }
+
+    [Fact]
+    public void Remove_ById_RemovesTheRightItem()
+    {
+        var q = new SendQueue();
+        var a = Msg("a");
+        var b = Msg("b");
+        q.Enqueue(a);
+        q.Enqueue(b);
+
+        Assert.True(q.Remove(a.Id));
+        Assert.Equal(1, q.Count);
+        Assert.Equal("b", q.Items[0].Text);
+        Assert.False(q.Remove(a.Id)); // already gone
+    }
+
+    [Fact]
+    public void Changed_FiresOnEnqueueRemoveDequeueAndClear()
+    {
+        var q = new SendQueue();
+        var count = 0;
+        q.Changed += () => count++;
+
+        var m = Msg("a");
+        q.Enqueue(m);      // 1
+        q.DequeueHead();   // 2
+        q.Enqueue(m);      // 3
+        q.Remove(m.Id);    // 4
+        q.Enqueue(m);      // 5
+        q.Clear();         // 6
+
+        Assert.Equal(6, count);
+    }
+
+    [Fact]
+    public void Clear_OnEmptyQueue_DoesNotFireChanged()
+    {
+        var q = new SendQueue();
+        var fired = false;
+        q.Changed += () => fired = true;
+        q.Clear();
+        Assert.False(fired);
+    }
+
+    [Fact]
+    public void NextScheduledFireUtc_ReturnsEarliestFutureTime()
+    {
+        var q = new SendQueue();
+        q.Enqueue(Msg("plain"));                       // no time gate
+        q.Enqueue(Msg("late", T0.AddHours(2)));
+        q.Enqueue(Msg("soon", T0.AddMinutes(30)));
+
+        Assert.Equal(T0.AddMinutes(30), q.NextScheduledFireUtc);
+    }
+
+    [Fact]
+    public void NextScheduledFireUtc_NullWhenNothingScheduled()
+    {
+        var q = new SendQueue();
+        q.Enqueue(Msg("a"));
+        q.Enqueue(Msg("b"));
+        Assert.Null(q.NextScheduledFireUtc);
+    }
+
+    [Fact]
+    public void RefreshStatus_PlainMessage_ReadsQueued()
+    {
+        var m = Msg("a");
+        m.RefreshStatus(T0);
+        Assert.Equal("Queued", m.StatusText);
+    }
+
+    [Fact]
+    public void RefreshStatus_ScheduledMessage_ShowsCountdownThenDue()
+    {
+        var m = Msg("a", T0.AddMinutes(5));
+
+        m.RefreshStatus(T0);
+        Assert.Equal("Scheduled · 05:00", m.StatusText);
+
+        m.RefreshStatus(T0.AddMinutes(5));
+        Assert.Equal("Scheduled · due", m.StatusText);
+    }
+
+    [Fact]
+    public void RefreshStatus_LongDelay_ShowsHours()
+    {
+        var m = Msg("a", T0.AddHours(1).AddMinutes(2).AddSeconds(3));
+        m.RefreshStatus(T0);
+        Assert.Equal("Scheduled · 01:02:03", m.StatusText);
+    }
+
+    [Fact]
+    public void Preview_CollapsesNewlinesAndTruncates()
+    {
+        var m = Msg("line one\nline two");
+        Assert.Equal("line one line two", m.Preview);
+
+        var longText = Msg(new string('x', 200));
+        Assert.Equal(101, longText.Preview.Length); // 100 chars + ellipsis
+        Assert.EndsWith("…", longText.Preview);
+    }
+}

--- a/tests/AgentDock.Tests/UserMessageSerializationTests.cs
+++ b/tests/AgentDock.Tests/UserMessageSerializationTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using AgentDock.Models;
+using AgentDock.Services;
+using Xunit;
+
+namespace AgentDock.Tests;
+
+/// <summary>
+/// Locks the stdin JSON shape produced for user messages — the contract Claude
+/// Code's stream-json input parses. Text-only messages must stay a plain string
+/// (the long-standing shape); image messages must become an Anthropic
+/// content-block array with base64 image sources.
+/// </summary>
+public class UserMessageSerializationTests
+{
+    private static JsonElement ParseContent(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("message").GetProperty("content").Clone();
+    }
+
+    [Fact]
+    public void TextOnly_SerializesContentAsPlainString()
+    {
+        var json = ClaudeSession.SerializeUserMessage("hello world", null);
+        var content = ParseContent(json);
+
+        Assert.Equal(JsonValueKind.String, content.ValueKind);
+        Assert.Equal("hello world", content.GetString());
+    }
+
+    [Fact]
+    public void EmptyImageList_SerializesContentAsPlainString()
+    {
+        var json = ClaudeSession.SerializeUserMessage("hi", new List<ImageAttachment>());
+        var content = ParseContent(json);
+
+        Assert.Equal(JsonValueKind.String, content.ValueKind);
+        Assert.Equal("hi", content.GetString());
+    }
+
+    [Fact]
+    public void WithImage_SerializesImageBlockThenTextBlock()
+    {
+        var images = new List<ImageAttachment> { new("image/png", "QUJD") };
+        var json = ClaudeSession.SerializeUserMessage("what is this?", images);
+        var content = ParseContent(json);
+
+        Assert.Equal(JsonValueKind.Array, content.ValueKind);
+        Assert.Equal(2, content.GetArrayLength());
+
+        // Images come first.
+        var image = content[0];
+        Assert.Equal("image", image.GetProperty("type").GetString());
+        var source = image.GetProperty("source");
+        Assert.Equal("base64", source.GetProperty("type").GetString());
+        Assert.Equal("image/png", source.GetProperty("media_type").GetString());
+        Assert.Equal("QUJD", source.GetProperty("data").GetString());
+
+        // Then the text block.
+        var text = content[1];
+        Assert.Equal("text", text.GetProperty("type").GetString());
+        Assert.Equal("what is this?", text.GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public void ImageWithoutText_OmitsTextBlock()
+    {
+        var images = new List<ImageAttachment> { new("image/jpeg", "Rk9P") };
+        var json = ClaudeSession.SerializeUserMessage("   ", images);
+        var content = ParseContent(json);
+
+        // Whitespace-only text is sent by the UI as-is here; SerializeUserMessage
+        // only drops genuinely empty text. The control trims before calling, so an
+        // image-only send arrives as "".
+        var jsonEmpty = ClaudeSession.SerializeUserMessage("", images);
+        var contentEmpty = ParseContent(jsonEmpty);
+
+        Assert.Equal(JsonValueKind.Array, contentEmpty.ValueKind);
+        Assert.Equal(1, contentEmpty.GetArrayLength());
+        Assert.Equal("image", contentEmpty[0].GetProperty("type").GetString());
+
+        // Sanity: the whitespace variant still includes a text block (not empty).
+        Assert.Equal(2, content.GetArrayLength());
+    }
+
+    [Fact]
+    public void MultipleImages_AllSerializeBeforeText()
+    {
+        var images = new List<ImageAttachment>
+        {
+            new("image/png", "AAAA"),
+            new("image/jpeg", "BBBB"),
+        };
+        var json = ClaudeSession.SerializeUserMessage("compare these", images);
+        var content = ParseContent(json);
+
+        Assert.Equal(3, content.GetArrayLength());
+        Assert.Equal("image", content[0].GetProperty("type").GetString());
+        Assert.Equal("image", content[1].GetProperty("type").GetString());
+        Assert.Equal("text", content[2].GetProperty("type").GetString());
+    }
+}


### PR DESCRIPTION
Release **v0.9.1**. Full notes: `docs/release-notes/v0.9.1.md`.

## Highlights
- **Chat — attach images**: paste (Ctrl+V) or drag-drop images, thumbnail chips + preview window, sent as native multimodal content (auto-downscaled/normalized). Cancel button to discard draft + attachments.
- **Chat — send queue**: queue follow-ups while Claude is working; strict FIFO; scheduling folded into the same queue; taller input box.
- **Chat — live subagent visibility**: ◆ Subagent line + captured ◆ report block (model-tagged); background tasks / subagents / workflows counted separately.
- **Tabs**: cyan ◷ clock glyph for a session with a scheduled message.
- **Git**: globe button to open the repo's origin page in the browser (GitHub/GitLab/Bitbucket/Codeberg/Azure DevOps, https + SSH).
- **Markdown**: selectable/copyable tables, clickable links, single-line inline-markdown rendering, bold/URL pairing fixes; readable table text in dark themes.
- **Fix**: no more premature completion chime / \$0 cost line on resume-flush results.

## Verification
- `dotnet test` — **86/86 passing**.
- App project compiles clean (exe-copy step was blocked only by a locally running instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)